### PR TITLE
Pass `BRANCH_NAME` to `repo init`

### DIFF
--- a/src/build.sh
+++ b/src/build.sh
@@ -31,7 +31,7 @@ if ! [ -z "$DEVICE_LIST" ]; then
   if ! [ "$(ls -A $SRC_DIR)" ]; then
     # Initialize repository
     echo ">> [$(date)] Initializing repository"
-    yes | repo init -u https://github.com/lineageos/android.git -b
+    yes | repo init -u https://github.com/lineageos/android.git -b ${BRANCH_NAME:-cm-14.1}
   fi
 
   # Copy local manifests to the appropriate folder in order take them into consideration


### PR DESCRIPTION
The `repo init` command has a `-b` option without value. We should probably pass the `${BRANCH_NAME}` here, defaulting to `cm-14.1`.