### PR TITLE
Add clang

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -164,12 +164,13 @@ RUN mkdir -p $USERSCRIPTS_DIR
 RUN apt-get -qq update
 RUN apt-get -qqy upgrade
 
-RUN apt-get install -y bc bison bsdmainutils build-essential ccache cgpt cron \
-      curl flex g++-multilib gcc-multilib git gnupg gperf imagemagick kmod \
-      lib32ncurses5-dev lib32readline-dev lib32z1-dev libesd0-dev liblz4-tool \
-      libncurses5-dev libsdl1.2-dev libssl-dev libwxgtk3.0-dev libxml2 \
-      libxml2-utils lsof lzop maven openjdk-8-jdk pngcrush procps python rsync \
-      schedtool squashfs-tools wget xdelta3 xsltproc yasm zip zlib1g-dev
+RUN apt-get install -y bc bison bsdmainutils build-essential ccache cgpt clang \
+      cron curl flex g++-multilib gcc-multilib git gnupg gperf imagemagick \
+      kmod lib32ncurses5-dev lib32readline-dev lib32z1-dev libesd0-dev \
+      liblz4-tool libncurses5-dev libsdl1.2-dev libssl-dev libwxgtk3.0-dev \
+      libxml2 libxml2-utils lsof lzop maven openjdk-8-jdk pngcrush procps \
+      python rsync schedtool squashfs-tools wget xdelta3 xsltproc yasm zip \
+      zlib1g-dev
 
 RUN curl https://storage.googleapis.com/git-repo-downloads/repo > /usr/local/bin/repo
 RUN chmod a+x /usr/local/bin/repo


### PR DESCRIPTION
Some devices need clang to build successfully, for example davinci (Xiaomi Mi 9T, which will soon be added to official devices)