### PR TITLE
move boot.img to output directory

### DIFF
--- a/src/build.sh
+++ b/src/build.sh
@@ -301,8 +301,8 @@ for branch in ${BRANCH_NAME//,/ }; do
             sha256sum "$build" > "$ZIP_DIR/$zipsubdir/$build.sha256sum"
           done
           find . -maxdepth 1 -name 'lineage-*.zip*' -type f -exec mv {} "$ZIP_DIR/$zipsubdir/" \; &>> "$DEBUG_LOG"
-	  recovery_name=$(echo "$build" | sed "s/.zip//")
-find . -maxdepth 1 -name 'boot.img' -type f -exec mv {} "$ZIP_DIR/$zipsubdir/${recovery_name}-recovery.img" \; &>> "$DEBUG_LOG"
+          recovery_name=lineage-$los_ver-$builddate-$RELEASE_TYPE-$codename-recovery.img
+          find . -maxdepth 1 -name 'boot.img' -type f -exec cp {} "$ZIP_DIR/$zipsubdir/${recovery_name}" \; &>> "$DEBUG_LOG"
           cd "$source_dir"
           build_successful=true
         else

--- a/src/build.sh
+++ b/src/build.sh
@@ -301,6 +301,8 @@ for branch in ${BRANCH_NAME//,/ }; do
             sha256sum "$build" > "$ZIP_DIR/$zipsubdir/$build.sha256sum"
           done
           find . -maxdepth 1 -name 'lineage-*.zip*' -type f -exec mv {} "$ZIP_DIR/$zipsubdir/" \; &>> "$DEBUG_LOG"
+	  recovery_name=$(echo "$build" | sed "s/.zip//")
+find . -maxdepth 1 -name 'boot.img' -type f -exec mv {} "$ZIP_DIR/$zipsubdir/${recovery_name}-recovery.img" \; &>> "$DEBUG_LOG"
           cd "$source_dir"
           build_successful=true
         else


### PR DESCRIPTION
move (and rename) boot.img so it can be exposed on the downloads page
fixes #134 