### PR TITLE
Lineage 18.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,12 +162,12 @@ When `LOCAL_MIRROR` is `true`:
 
 ## Examples
 
-### Build for bacon (lineage-16.0, officially supported), test keys, no patches
+### Build for river (lineage-18.1, officially supported), test keys, no patches
 
 ```
 docker run \
-    -e "BRANCH_NAME=lineage-16.0" \
-    -e "DEVICE_LIST=bacon" \
+    -e "BRANCH_NAME=lineage-18.1" \
+    -e "DEVICE_LIST=river" \
     -v "/home/user/lineage:/srv/src" \
     -v "/home/user/zips:/srv/zips" \
     -v "/home/user/logs:/srv/logs" \
@@ -175,12 +175,12 @@ docker run \
     lineageos4microg/docker-lineage-cicd
 ```
 
-### Build for angler (lineage-15.1, officially supported), custom keys, restricted signature spoofing with integrated microG and FDroid
+### Build for bacon (lineage-17.1, officially supported), custom keys, restricted signature spoofing with integrated microG and FDroid
 
 ```
 docker run \
-    -e "BRANCH_NAME=lineage-15.1" \
-    -e "DEVICE_LIST=angler" \
+    -e "BRANCH_NAME=lineage-17.1" \
+    -e "DEVICE_LIST=bacon" \
     -e "SIGN_BUILDS=true" \
     -e "SIGNATURE_SPOOFING=restricted" \
     -e "CUSTOM_PACKAGES=GmsCore GsfProxy FakeStore MozillaNlpBackend NominatimNlpBackend com.google.android.maps.jar FDroid FDroidPrivilegedExtension " \
@@ -210,13 +210,13 @@ it ends with `.xml`) in the `/home/user/manifests` folder with this content:
 </manifest>
 ```
 
-### Build for four devices on lineage-15.1 and lineage-16.0 (officially supported), custom keys, restricted signature spoofing with integrated microG and FDroid, custom OTA server
+### Build for four devices on lineage-17.1 and lineage-18.1 (officially supported), custom keys, restricted signature spoofing with integrated microG and FDroid, custom OTA server
 
 ```
 docker run \
-    -e "BRANCH_NAME=lineage-15.1,lineage-16.0" \
-    -e "DEVICE_LIST_LINEAGE_15_1=angler,oneplus2" \
-    -e "DEVICE_LIST_LINEAGE_16_0=bacon,dumpling" \
+    -e "BRANCH_NAME=lineage-17.1,lineage-18.1" \
+    -e "DEVICE_LIST_LINEAGE_17_1=bacon,oneplus2" \
+    -e "DEVICE_LIST_LINEAGE_18_1=river,lake" \
     -e "SIGN_BUILDS=true" \
     -e "SIGNATURE_SPOOFING=restricted" \
     -e "CUSTOM_PACKAGES=GmsCore GsfProxy FakeStore MozillaNlpBackend NominatimNlpBackend com.google.android.maps.jar FDroid FDroidPrivilegedExtension " \

--- a/src/build.sh
+++ b/src/build.sh
@@ -182,7 +182,7 @@ for branch in ${BRANCH_NAME//,/ }; do
       if [ "$SIGNATURE_SPOOFING" = "yes" ]; then
         echo ">> [$(date)] Applying the standard signature spoofing patch ($patch_name) to frameworks/base"
         echo ">> [$(date)] WARNING: the standard signature spoofing patch introduces a security threat"
-        patch --quiet -p1 -i "/root/signature_spoofing_patches/$patch_name"
+        patch --quiet --force -p1 -i "/root/signature_spoofing_patches/$patch_name"
       else
         echo ">> [$(date)] Applying the restricted signature spoofing patch (based on $patch_name) to frameworks/base"
         sed 's/android:protectionLevel="dangerous"/android:protectionLevel="signature|privileged"/' "/root/signature_spoofing_patches/$patch_name" | patch --quiet -p1
@@ -193,7 +193,7 @@ for branch in ${BRANCH_NAME//,/ }; do
       if ! [ -z "$permissioncontroller_patch" ]; then
         cd packages/apps/PermissionController
         echo ">> [$(date)] Applying the PermissionController patch ($permissioncontroller_patch) to packages/apps/PermissionController"
-        patch --quiet -p1 -i "/root/signature_spoofing_patches/$permissioncontroller_patch"
+        patch --quiet --force -p1 -i "/root/signature_spoofing_patches/$permissioncontroller_patch"
         if [ $? -ne 0 ]; then
           echo ">> [$(date)] ERROR: failed to apply $permissioncontroller_patch"
           exit 1

--- a/src/build.sh
+++ b/src/build.sh
@@ -187,6 +187,10 @@ for branch in ${BRANCH_NAME//,/ }; do
         echo ">> [$(date)] Applying the restricted signature spoofing patch (based on $patch_name) to frameworks/base"
         sed 's/android:protectionLevel="dangerous"/android:protectionLevel="signature|privileged"/' "/root/signature_spoofing_patches/$patch_name" | patch --quiet -p1
       fi
+      if [ $? -ne 0 ]; then
+        echo ">> [$(date)] ERROR: failed to apply $patch_name"
+        exit 1
+      fi
       git clean -q -f
       cd ../..
 

--- a/src/signature_spoofing_patches/android_frameworks_base-R.patch
+++ b/src/signature_spoofing_patches/android_frameworks_base-R.patch
@@ -1,0 +1,131 @@
+--- a/api/current.txt
++++ b/api/current.txt
+@@ -77,6 +77,7 @@ package android {
+     field public static final String DIAGNOSTIC = "android.permission.DIAGNOSTIC";
+     field public static final String DISABLE_KEYGUARD = "android.permission.DISABLE_KEYGUARD";
+     field public static final String DUMP = "android.permission.DUMP";
++    field public static final String FAKE_PACKAGE_SIGNATURE = "android.permission.FAKE_PACKAGE_SIGNATURE";
+     field public static final String EXPAND_STATUS_BAR = "android.permission.EXPAND_STATUS_BAR";
+     field public static final String FACTORY_TEST = "android.permission.FACTORY_TEST";
+     field public static final String FOREGROUND_SERVICE = "android.permission.FOREGROUND_SERVICE";
+@@ -182,6 +182,7 @@ package android {
+     field public static final String CALL_LOG = "android.permission-group.CALL_LOG";
+     field public static final String CAMERA = "android.permission-group.CAMERA";
+     field public static final String CONTACTS = "android.permission-group.CONTACTS";
++    field public static final String FAKE_PACKAGE = "android.permission-group.FAKE_PACKAGE";
+     field public static final String LOCATION = "android.permission-group.LOCATION";
+     field public static final String MICROPHONE = "android.permission-group.MICROPHONE";
+     field public static final String PHONE = "android.permission-group.PHONE";
+--- a/core/res/AndroidManifest.xml
++++ b/core/res/AndroidManifest.xml
+@@ -2841,6 +2841,21 @@
+         android:description="@string/permdesc_getPackageSize"
+         android:protectionLevel="normal" />
+ 
++    <!-- Dummy user-facing group for faking package signature -->
++    <permission-group android:name="android.permission-group.FAKE_PACKAGE"
++        android:label="@string/permgrouplab_fake_package_signature"
++        android:description="@string/permgroupdesc_fake_package_signature"
++        android:request="@string/permgrouprequest_fake_package_signature"
++        android:priority="100" />
++
++    <!-- Allows an application to change the package signature as
++         seen by applications -->
++    <permission android:name="android.permission.FAKE_PACKAGE_SIGNATURE"
++        android:permissionGroup="android.permission-group.UNDEFINED"
++        android:protectionLevel="dangerous"
++        android:label="@string/permlab_fakePackageSignature"
++        android:description="@string/permdesc_fakePackageSignature" />
++
+     <!-- @deprecated No longer useful, see
+          {@link android.content.pm.PackageManager#addPackageToPreferred}
+          for details. -->
+--- a/core/res/res/values/config.xml
++++ b/core/res/res/values/config.xml
+@@ -1654,6 +1654,8 @@
+     <string-array name="config_locationProviderPackageNames" translatable="false">
+         <!-- The standard AOSP fused location provider -->
+         <item>com.android.location.fused</item>
++        <!-- Google Play Services or microG (free reimplementation) location provider -->
++        <item>com.google.android.gms</item>
+     </string-array>
+ 
+     <!-- This string array can be overriden to enable test location providers initially. -->
+--- a/core/res/res/values/strings.xml
++++ b/core/res/res/values/strings.xml
+@@ -847,6 +847,18 @@
+ 
+     <!--  Permissions -->
+ 
++    <!-- Title of an application permission, listed so the user can choose whether they want to allow the application to do this. -->
++    <string name="permlab_fakePackageSignature">Spoof package signature</string>
++    <!-- Description of an application permission, listed so the user can choose whether they want to allow the application to do this. -->
++    <string name="permdesc_fakePackageSignature">Allows the app to pretend to be a different app. Malicious applications might be able to use this to access private application data. Legitimate uses include an emulator pretending to be what it emulates. Grant this permission with caution only!</string>
++    <!-- Title of a category of application permissions, listed so the user can choose whether they want to allow the application to do this. -->
++    <string name="permgrouplab_fake_package_signature">Spoof package signature</string>
++    <!-- Description of a category of application permissions, listed so the user can choose whether they want to allow the application to do this. -->
++    <string name="permgroupdesc_fake_package_signature">allow to spoof package signature</string>
++    <!-- Message shown to the user when the apps requests permission from this group. If ever possible this should stay below 80 characters (assuming the parameters takes 20 characters). Don't abbreviate until the message reaches 120 characters though. [CHAR LIMIT=120] -->
++    <string name="permgrouprequest_fake_package_signature">Allow
++        &lt;b><xliff:g id="app_name" example="Gmail">%1$s</xliff:g>&lt;/b> to spoof package signature?</string>
++
+     <!-- Title of an application permission, listed so the user can choose whether they want to allow the application to do this. -->
+     <string name="permlab_statusBar">disable or modify status bar</string>
+     <!-- Description of an application permission, listed so the user can choose whether they want to allow the application to do this. -->
+--- a/non-updatable-api/current.txt
++++ b/non-updatable-api/current.txt
+@@ -79,6 +79,7 @@ package android {
+     field public static final String DUMP = "android.permission.DUMP";
+     field public static final String EXPAND_STATUS_BAR = "android.permission.EXPAND_STATUS_BAR";
+     field public static final String FACTORY_TEST = "android.permission.FACTORY_TEST";
++    field public static final String FAKE_PACKAGE_SIGNATURE = "android.permission.FAKE_PACKAGE_SIGNATURE";
+     field public static final String FOREGROUND_SERVICE = "android.permission.FOREGROUND_SERVICE";
+     field public static final String GET_ACCOUNTS = "android.permission.GET_ACCOUNTS";
+     field public static final String GET_ACCOUNTS_PRIVILEGED = "android.permission.GET_ACCOUNTS_PRIVILEGED";
+@@ -182,6 +183,7 @@ package android {
+     field public static final String CALL_LOG = "android.permission-group.CALL_LOG";
+     field public static final String CAMERA = "android.permission-group.CAMERA";
+     field public static final String CONTACTS = "android.permission-group.CONTACTS";
++    field public static final String FAKE_PACKAGE = "android.permission-group.FAKE_PACKAGE";
+     field public static final String LOCATION = "android.permission-group.LOCATION";
+     field public static final String MICROPHONE = "android.permission-group.MICROPHONE";
+     field public static final String PHONE = "android.permission-group.PHONE";
+--- a/services/core/java/com/android/server/pm/PackageManagerService.java
++++ b/services/core/java/com/android/server/pm/PackageManagerService.java
+@@ -4454,8 +4454,9 @@
+                 });
+             }
+ 
+-            PackageInfo packageInfo = PackageInfoUtils.generate(p, gids, flags,
+-                    ps.firstInstallTime, ps.lastUpdateTime, permissions, state, userId, ps);
++            PackageInfo packageInfo = mayFakeSignature(p, PackageInfoUtils.generate(p, gids, flags,
++                    ps.firstInstallTime, ps.lastUpdateTime, permissions, state, userId, ps),
++                    permissions);
+ 
+             if (packageInfo == null) {
+                 return null;
+@@ -4491,6 +4492,24 @@
+         }
+     }
+ 
++    private PackageInfo mayFakeSignature(AndroidPackage p, PackageInfo pi,
++            Set<String> permissions) {
++        try {
++            if (permissions.contains("android.permission.FAKE_PACKAGE_SIGNATURE")
++                    && p.getTargetSdkVersion() > Build.VERSION_CODES.LOLLIPOP_MR1
++                    && p.getMetaData() != null) {
++                String sig = p.getMetaData().getString("fake-signature");
++                if (sig != null) {
++                    pi.signatures = new Signature[] {new Signature(sig)};
++                }
++            }
++        } catch (Throwable t) {
++            // We should never die because of any failures, this is system code!
++            Log.w("PackageManagerService.FAKE_PACKAGE_SIGNATURE", t);
++        }
++        return pi;
++    }
++
+     @Override
+     public void checkPackageStartable(String packageName, int userId) {
+         final int callingUid = Binder.getCallingUid();

--- a/src/signature_spoofing_patches/packages_apps_PermissionController-R.patch
+++ b/src/signature_spoofing_patches/packages_apps_PermissionController-R.patch
@@ -1,0 +1,19 @@
+--- a/src/com/android/permissioncontroller/permission/utils/Utils.java
++++ b/src/com/android/permissioncontroller/permission/utils/Utils.java
+@@ -23,6 +23,7 @@
+ import static android.Manifest.permission_group.CALL_LOG;
+ import static android.Manifest.permission_group.CAMERA;
+ import static android.Manifest.permission_group.CONTACTS;
++import static android.Manifest.permission_group.FAKE_PACKAGE;
+ import static android.Manifest.permission_group.LOCATION;
+ import static android.Manifest.permission_group.MICROPHONE;
+ import static android.Manifest.permission_group.PHONE;
+@@ -209,6 +210,8 @@
+ 
+         PLATFORM_PERMISSIONS.put(Manifest.permission.BODY_SENSORS, SENSORS);
+ 
++        PLATFORM_PERMISSIONS.put(Manifest.permission.FAKE_PACKAGE_SIGNATURE, FAKE_PACKAGE);
++
+         PLATFORM_PERMISSION_GROUPS = new ArrayMap<>();
+         int numPlatformPermissions = PLATFORM_PERMISSIONS.size();
+         for (int i = 0; i < numPlatformPermissions; i++) {


### PR DESCRIPTION
see #139 

Built successfully for me with target device `river`.

I think this can be merged when:

* [x] I have tested my build on device and don't find any errors that can be traced back to the build process
* [x] Upstream LineageOS provides official 18.1 builds. Follow progress [on gerrit](https://review.lineageos.org/q/topic:%2522eighteen%2522).
* [x] the-muppets provide an 18.1 manifest [on GitLab](https://gitlab.com/the-muppets/manifest/-/blob/lineage-17.1/muppets.xml). Maybe they will also cover xiaomi devices in their manifest [on GitHub](https://github.com/TheMuppets/manifests/blob/lineage-18.1/muppets.xml) and we need to change the references in `build.xml` - I don't really understand this stuff.