### PR TITLE
copy build.prop file together with zip

### DIFF
--- a/src/build.sh
+++ b/src/build.sh
@@ -299,6 +299,7 @@ for branch in ${BRANCH_NAME//,/ }; do
           cd out/target/product/$codename
           for build in lineage-*.zip; do
             sha256sum "$build" > "$ZIP_DIR/$zipsubdir/$build.sha256sum"
+            cp -v system/build.prop "$ZIP_DIR/$zipsubdir/$build.prop" &>> "$DEBUG_LOG"
           done
           find . -maxdepth 1 -name 'lineage-*.zip*' -type f -exec mv {} "$ZIP_DIR/$zipsubdir/" \; &>> "$DEBUG_LOG"
           recovery_name="lineage-$los_ver-$builddate-$RELEASE_TYPE-$codename-recovery.img"


### PR DESCRIPTION
Copies the build.prop file to the zip directory, named as the zip file with `.prop` appended. This is the filename [LineageOTA](https://github.com/julianxhokaxhiu/LineageOTA#only-for-lineageos-15x-and-newer) expects.