### PR TITLE
Update build_manifest.py to get rid of python2->3 related error

### DIFF
--- a/src/build_manifest.py
+++ b/src/build_manifest.py
@@ -58,4 +58,4 @@ if __name__ == "__main__":
 
     xmlstr = minidom.parseString(ET.tostring(xmlout)).toprettyxml(indent="  ", encoding="UTF-8")
     with open(args.out, "w") as f:
-        f.write(xmlstr)
+        f.write(xmlstr.decode('utf-8'))


### PR DESCRIPTION
I was using the build scripts outside of Docker in an environment with Python 3, and I saw the following error when the script ran
```
f.write(xmlstr)
TypeError: write() argument must be str, not bytes
```
This change makes the error go away, and allows the script to work with both Python 2 and 3