### PR TITLE
[Feature] Allow building without Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,17 @@ When `LOCAL_MIRROR` is `true`:
 
  * `/srv/mirror`, for the LineageOS mirror
 
+## Build without Docker (experimental)
+
+We also provide some limited effort to build without Docker in a subdirectory.
+The main advantage is that root is not required.
+
+To do so, please execute the following steps:
+
+1. Install all necessary dependencies. Take a look at the [Dockerfile][dockerfile]
+   to get a list (especially the RUN commands with apt-get).
+2. Execute `run.py` with your specific environment. See `run.py -h` for help.
+
 ## Examples
 
 ### Build for river (lineage-18.1, officially supported), test keys, no patches

--- a/run.py
+++ b/run.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+
+# Docker wrapper script
+# Copyright (c) 2021 Fjen <fjen@neboola.de>
+# Copyright (C) 2021 Gerion Entrup <gerion.entrup@flump.de>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Build Lineage OS with MicroG without Docker."""
+
+import argparse
+import functools
+import logging
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Iterator, Dict
+
+
+def get_docker_cmd(docker_file: str) -> Iterator[str]:
+    """Extract commands from Dockerfile."""
+    with open(docker_file) as f:
+        prev_lines = ""
+        for line in f:
+            if line.startswith("#") or not line.strip():
+                # ignore comments / empty lines
+                pass
+            elif line.endswith("\\\n"):
+                # save multi line commands
+                prev_lines += line.strip().rstrip("\\")
+            else:
+                yield prev_lines + line.strip()
+                prev_lines = ""
+
+
+def with_prefix(prefix: str, path: str) -> str:
+    """Add prefix to path"""
+    return str(Path(prefix + path).absolute())
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        prog=sys.argv[0],
+        description=sys.modules[__name__].__doc__,
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument(
+        "--docker-file",
+        "-d",
+        help="docker file that should be converted",
+        default="./Dockerfile",
+    )
+    parser.add_argument(
+        "--prefix",
+        "-p",
+        help="set prefix path (all build files will reside in this folder)",
+        default="./build",
+    )
+    parser.add_argument(
+        "--env",
+        "-e",
+        help="set an environment variable",
+        metavar="KEY=VALUE",
+        action="append",
+        default=[],
+    )
+    parser.add_argument(
+        "--verbose",
+        "-v",
+        help="output more log messages",
+        action="store_true",
+        default=False,
+    )
+
+    args = parser.parse_args()
+    with_p = functools.partial(with_prefix, args.prefix)
+
+    logging.basicConfig(
+        format="%(asctime)s %(name)s: %(message)s",
+        level=logging.INFO if args.verbose else logging.WARNING,
+    )
+
+    env: Dict[str, str] = dict()
+    env["PREFIX"] = str(Path(args.prefix).absolute())
+    env["HOME"] = os.environ.get("HOME", "/")
+    for env_var in args.env:
+        key, value = env_var.split("=")
+        env[key] = value
+
+    workdir = "/"
+    for cmd in get_docker_cmd(args.docker_file):
+        cmd, *values = cmd.split(maxsplit=2)
+        if cmd == "ENV" and values[0] not in env:
+            # set environment
+            env_value = values[1].strip("\"'")
+            if values[0].endswith("_DIR"):
+                env_value = with_p(env_value)
+            env[values[0]] = env_value
+        elif cmd == "RUN" and values[0] == "mkdir":
+            # execute mkdirs
+            subprocess.Popen(" ".join(values), env=env, shell=True).wait()
+        elif cmd == "COPY":
+            # copy files
+            # FIXME: change to dirs_exists_ok=true with Python 3.8 instead of
+            # removing the entire subtree
+            shutil.rmtree(with_p(values[1]), ignore_errors=True)
+            shutil.copytree(values[0], with_p(values[1]))
+        elif cmd == "WORKDIR":
+            # set workdir to env value if referenced, static otherwise
+            workdir = env.get(values[0].lstrip("$"), values[0])
+        elif cmd == "ENTRYPOINT":
+            # start build
+            cmd = with_p(values[0])
+            pretty_env = "\n".join([f"{x}={y}" for x, y in sorted(env.items())])
+            logging.info("Starting build process.")
+            logging.info(f"Command: {cmd}")
+            logging.info(f"Environment:\n{pretty_env}")
+            logging.info(f"Working directory: {workdir}")
+            subprocess.Popen(
+                cmd, cwd=workdir, env={**os.environ, **env}, shell=True
+            ).wait()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/build.sh
+++ b/src/build.sh
@@ -22,9 +22,9 @@ repo_log="$LOGS_DIR/repo-$(date +%Y%m%d).log"
 # cd to working directory
 cd "$SRC_DIR"
 
-if [ -f /root/userscripts/begin.sh ]; then
+if [ -f "$PREFIX"/root/userscripts/begin.sh ]; then
   echo ">> [$(date)] Running begin.sh"
-  /root/userscripts/begin.sh
+  "$PREFIX"/root/userscripts/begin.sh
 fi
 
 # If requested, clean the OUT dir in order to avoid clutter
@@ -70,7 +70,7 @@ if [ "$LOCAL_MIRROR" = true ]; then
   rm -f .repo/local_manifests/proprietary.xml
   if [ "$INCLUDE_PROPRIETARY" = true ]; then
     wget -q -O .repo/local_manifests/proprietary.xml "https://raw.githubusercontent.com/TheMuppets/manifests/mirror/default.xml"
-    /root/build_manifest.py --remote "https://gitlab.com" --remotename "gitlab_https" \
+    "$PREFIX"/root/build_manifest.py --remote "https://gitlab.com" --remotename "gitlab_https" \
       "https://gitlab.com/the-muppets/manifest/raw/mirror/default.xml" .repo/local_manifests/proprietary_gitlab.xml
   fi
 
@@ -154,7 +154,7 @@ for branch in ${BRANCH_NAME//,/ }; do
     rm -f .repo/local_manifests/proprietary.xml
     if [ "$INCLUDE_PROPRIETARY" = true ]; then
       wget -q -O .repo/local_manifests/proprietary.xml "https://raw.githubusercontent.com/TheMuppets/manifests/$themuppets_branch/muppets.xml"
-      /root/build_manifest.py --remote "https://gitlab.com" --remotename "gitlab_https" \
+      "$PREFIX"/root/build_manifest.py --remote "https://gitlab.com" --remotename "gitlab_https" \
         "https://gitlab.com/the-muppets/manifest/raw/$themuppets_branch/muppets.xml" .repo/local_manifests/proprietary_gitlab.xml
     fi
 
@@ -182,10 +182,10 @@ for branch in ${BRANCH_NAME//,/ }; do
       if [ "$SIGNATURE_SPOOFING" = "yes" ]; then
         echo ">> [$(date)] Applying the standard signature spoofing patch ($patch_name) to frameworks/base"
         echo ">> [$(date)] WARNING: the standard signature spoofing patch introduces a security threat"
-        patch --quiet --force -p1 -i "/root/signature_spoofing_patches/$patch_name"
+        patch --quiet --force -p1 -i "$PREFIX/root/signature_spoofing_patches/$patch_name"
       else
         echo ">> [$(date)] Applying the restricted signature spoofing patch (based on $patch_name) to frameworks/base"
-        sed 's/android:protectionLevel="dangerous"/android:protectionLevel="signature|privileged"/' "/root/signature_spoofing_patches/$patch_name" | patch --quiet -p1
+        sed 's/android:protectionLevel="dangerous"/android:protectionLevel="signature|privileged"/' "$PREFIX/root/signature_spoofing_patches/$patch_name" | patch --quiet -p1
       fi
       if [ $? -ne 0 ]; then
         echo ">> [$(date)] ERROR: failed to apply $patch_name"
@@ -197,7 +197,7 @@ for branch in ${BRANCH_NAME//,/ }; do
       if ! [ -z "$permissioncontroller_patch" ]; then
         cd packages/apps/PermissionController
         echo ">> [$(date)] Applying the PermissionController patch ($permissioncontroller_patch) to packages/apps/PermissionController"
-        patch --quiet --force -p1 -i "/root/signature_spoofing_patches/$permissioncontroller_patch"
+        patch --quiet --force -p1 -i "$PREFIX/root/signature_spoofing_patches/$permissioncontroller_patch"
         if [ $? -ne 0 ]; then
           echo ">> [$(date)] ERROR: failed to apply $permissioncontroller_patch"
           exit 1
@@ -208,7 +208,7 @@ for branch in ${BRANCH_NAME//,/ }; do
 
       # Override device-specific settings for the location providers
       mkdir -p "vendor/$vendor/overlay/microg/frameworks/base/core/res/res/values/"
-      cp /root/signature_spoofing_patches/frameworks_base_config.xml "vendor/$vendor/overlay/microg/frameworks/base/core/res/res/values/config.xml"
+      cp "$PREFIX"/root/signature_spoofing_patches/frameworks_base_config.xml "vendor/$vendor/overlay/microg/frameworks/base/core/res/res/values/config.xml"
     fi
 
     echo ">> [$(date)] Setting \"$RELEASE_TYPE\" as release type"
@@ -222,10 +222,10 @@ for branch in ${BRANCH_NAME//,/ }; do
 
       if [ -n "$(grep updater_server_url packages/apps/Updater/res/values/strings.xml)" ]; then
         # "New" updater configuration: full URL (with placeholders {device}, {type} and {incr})
-        sed "s|{name}|updater_server_url|g; s|{url}|$OTA_URL/v1/{device}/{type}/{incr}|g" /root/packages_updater_strings.xml > "$updater_url_overlay_dir/strings.xml"
+        sed "s|{name}|updater_server_url|g; s|{url}|$OTA_URL/v1/{device}/{type}/{incr}|g" "$PREFIX"/root/packages_updater_strings.xml > "$updater_url_overlay_dir/strings.xml"
       elif [ -n "$(grep conf_update_server_url_def packages/apps/Updater/res/values/strings.xml)" ]; then
         # "Old" updater configuration: just the URL
-        sed "s|{name}|conf_update_server_url_def|g; s|{url}|$OTA_URL|g" /root/packages_updater_strings.xml > "$updater_url_overlay_dir/strings.xml"
+        sed "s|{name}|conf_update_server_url_def|g; s|{url}|$OTA_URL|g" "$PREFIX"/root/packages_updater_strings.xml > "$updater_url_overlay_dir/strings.xml"
       else
         echo ">> [$(date)] ERROR: no known Updater URL property found"
         exit 1
@@ -255,9 +255,9 @@ for branch in ${BRANCH_NAME//,/ }; do
     echo ">> [$(date)] Preparing build environment"
     source build/envsetup.sh > /dev/null
 
-    if [ -f /root/userscripts/before.sh ]; then
+    if [ -f "$PREFIX"/root/userscripts/before.sh ]; then
       echo ">> [$(date)] Running before.sh"
-      /root/userscripts/before.sh
+      "$PREFIX"/root/userscripts/before.sh
     fi
 
     for codename in ${devices//,/ }; do
@@ -303,9 +303,9 @@ for branch in ${BRANCH_NAME//,/ }; do
 
         DEBUG_LOG="$LOGS_DIR/$logsubdir/lineage-$los_ver-$builddate-$RELEASE_TYPE-$codename.log"
 
-        if [ -f /root/userscripts/pre-build.sh ]; then
+        if [ -f "$PREFIX"/root/userscripts/pre-build.sh ]; then
           echo ">> [$(date)] Running pre-build.sh for $codename" >> "$DEBUG_LOG"
-          /root/userscripts/pre-build.sh $codename &>> "$DEBUG_LOG"
+          "$PREFIX"/root/userscripts/pre-build.sh $codename &>> "$DEBUG_LOG"
         fi
 
         # Start the build
@@ -314,7 +314,7 @@ for branch in ${BRANCH_NAME//,/ }; do
         if brunch $codename &>> "$DEBUG_LOG"; then
           currentdate=$(date +%Y%m%d)
           if [ "$builddate" != "$currentdate" ]; then
-            find out/target/product/$codename -maxdepth 1 -name "lineage-*-$currentdate-*.zip*" -type f -exec sh /root/fix_build_date.sh {} $currentdate $builddate \; &>> "$DEBUG_LOG"
+            find out/target/product/$codename -maxdepth 1 -name "lineage-*-$currentdate-*.zip*" -type f -exec sh "$PREFIX"/root/fix_build_date.sh {} $currentdate $builddate \; &>> "$DEBUG_LOG"
           fi
 
           # Move produced ZIP files to the main OUT directory
@@ -340,21 +340,21 @@ for branch in ${BRANCH_NAME//,/ }; do
         # Remove old zips and logs
         if [ "$DELETE_OLD_ZIPS" -gt "0" ]; then
           if [ "$ZIP_SUBDIR" = true ]; then
-            /usr/bin/python /root/clean_up.py -n $DELETE_OLD_ZIPS -V $los_ver -N 1 "$ZIP_DIR/$zipsubdir"
+            /usr/bin/python "$PREFIX"/root/clean_up.py -n $DELETE_OLD_ZIPS -V $los_ver -N 1 "$ZIP_DIR/$zipsubdir"
           else
-            /usr/bin/python /root/clean_up.py -n $DELETE_OLD_ZIPS -V $los_ver -N 1 -c $codename "$ZIP_DIR"
+            /usr/bin/python "$PREFIX"/root/clean_up.py -n $DELETE_OLD_ZIPS -V $los_ver -N 1 -c $codename "$ZIP_DIR"
           fi
         fi
         if [ "$DELETE_OLD_LOGS" -gt "0" ]; then
           if [ "$LOGS_SUBDIR" = true ]; then
-            /usr/bin/python /root/clean_up.py -n $DELETE_OLD_LOGS -V $los_ver -N 1 "$LOGS_DIR/$logsubdir"
+            /usr/bin/python "$PREFIX"/root/clean_up.py -n $DELETE_OLD_LOGS -V $los_ver -N 1 "$LOGS_DIR/$logsubdir"
           else
-            /usr/bin/python /root/clean_up.py -n $DELETE_OLD_LOGS -V $los_ver -N 1 -c $codename "$LOGS_DIR"
+            /usr/bin/python "$PREFIX"/root/clean_up.py -n $DELETE_OLD_LOGS -V $los_ver -N 1 -c $codename "$LOGS_DIR"
           fi
         fi
-        if [ -f /root/userscripts/post-build.sh ]; then
+        if [ -f "$PREFIX"/root/userscripts/post-build.sh ]; then
           echo ">> [$(date)] Running post-build.sh for $codename" >> "$DEBUG_LOG"
-          /root/userscripts/post-build.sh $codename $build_successful &>> "$DEBUG_LOG"
+          "$PREFIX"/root/userscripts/post-build.sh $codename $build_successful &>> "$DEBUG_LOG"
         fi
         echo ">> [$(date)] Finishing build for $codename" | tee -a "$DEBUG_LOG"
 
@@ -394,7 +394,7 @@ if [ "$DELETE_OLD_LOGS" -gt "0" ]; then
   find "$LOGS_DIR" -maxdepth 1 -name repo-*.log | sort | head -n -$DELETE_OLD_LOGS | xargs -r rm
 fi
 
-if [ -f /root/userscripts/end.sh ]; then
+if [ -f "$PREFIX"/root/userscripts/end.sh ]; then
   echo ">> [$(date)] Running end.sh"
-  /root/userscripts/end.sh
+  "$PREFIX"/root/userscripts/end.sh
 fi

--- a/src/init.sh
+++ b/src/init.sh
@@ -18,10 +18,10 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 # Copy the user scripts
-mkdir -p /root/userscripts
-cp -r $USERSCRIPTS_DIR/. /root/userscripts
-find /root/userscripts ! -type d ! -user root -exec echo ">> [$(date)] {} is not owned by root, removing" \; -exec rm {} \;
-find /root/userscripts ! -type d -perm /g=w,o=w -exec echo ">> [$(date)] {} is writable by non-root users, removing" \; -exec rm {} \;
+mkdir -p "$PREFIX"/root/userscripts
+cp -r $USERSCRIPTS_DIR/. "$PREFIX"/root/userscripts
+find "$PREFIX"/root/userscripts ! -type d ! -user root -exec echo ">> [$(date)] {} is not owned by root, removing" \; -exec rm {} \;
+find "$PREFIX"/root/userscripts ! -type d -perm /g=w,o=w -exec echo ">> [$(date)] {} is writable by non-root users, removing" \; -exec rm {} \;
 
 # Initialize CCache if it will be used
 if [ "$USE_CCACHE" = 1 ]; then
@@ -37,7 +37,7 @@ if [ "$SIGN_BUILDS" = true ]; then
     echo ">> [$(date)] SIGN_BUILDS = true but empty \$KEYS_DIR, generating new keys"
     for c in releasekey platform shared media networkstack; do
       echo ">> [$(date)]  Generating $c..."
-      /root/make_key "$KEYS_DIR/$c" "$KEYS_SUBJECT" <<< '' &> /dev/null
+      "$PREFIX"/root/make_key "$KEYS_DIR/$c" "$KEYS_SUBJECT" <<< '' &> /dev/null
     done
   else
     for c in releasekey platform shared media networkstack; do
@@ -58,13 +58,13 @@ if [ "$SIGN_BUILDS" = true ]; then
 fi
 
 if [ "$CRONTAB_TIME" = "now" ]; then
-  /root/build.sh
+  "$PREFIX"/root/build.sh
 else
   # Initialize the cronjob
   cronFile=/tmp/buildcron
   printf "SHELL=/bin/bash\n" > $cronFile
   printenv -0 | sed -e 's/=\x0/=""\n/g'  | sed -e 's/\x0/\n/g' | sed -e "s/_=/PRINTENV=/g" >> $cronFile
-  printf "\n$CRONTAB_TIME /usr/bin/flock -n /var/lock/build.lock /root/build.sh >> /var/log/docker.log 2>&1\n" >> $cronFile
+  printf "\n$CRONTAB_TIME /usr/bin/flock -n /var/lock/build.lock $PREFIX/root/build.sh >> /var/log/docker.log 2>&1\n" >> $cronFile
   crontab $cronFile
   rm $cronFile
 


### PR DESCRIPTION
Docker is a nice tool to deploy software on random devices since it bundles all dependencies. However, it has the big disadvantage that it [requires root](https://docs.docker.com/engine/security/#docker-daemon-attack-surface). Docker is also the only point in the whole build process that requires root, so it effectively permits the usage on servers where one only have a user account.

This pull request allows building LineageOS without root. It aims to be minimal invasive and should not change anything of the normal usage with Docker. The mechanism is to add a special `$PREFIX` path to all (otherwise) hardcoded absolute paths. Setting `$PREFIX` to an empty string leaves the setup as is. Setting `$PREFIX` to a user writables directory supports building anywhere in the system. The Dockerfile handling is done by a simple Python script that mainly reads the environment variables and executes `init.sh`.

We tested buidling without Docker successfully on Debian Buster.