### PR TITLE
Limit number of parallel jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ Other useful settings are:
  * `CRONTAB_TIME (now)`: instead of building immediately and exit, build at the
     specified time (uses standard cron format)
  * `ZIP_SUBDIR (true)`: Move the resulting zips to $ZIP_DIR/$codename instead of $ZIP_DIR/
+ * `PARALLEL_JOBS`: Limit the number of parallel jobs to run. (`-j` for `repo sync` and `mka`)
 
 The full list of settings, including the less interesting ones not mentioned in
 this guide, can be found in the [Dockerfile][dockerfile].

--- a/README.md
+++ b/README.md
@@ -177,7 +177,9 @@ Other useful settings are:
  * `CRONTAB_TIME (now)`: instead of building immediately and exit, build at the
     specified time (uses standard cron format)
  * `ZIP_SUBDIR (true)`: Move the resulting zips to $ZIP_DIR/$codename instead of $ZIP_DIR/
- * `PARALLEL_JOBS`: Limit the number of parallel jobs to run. (`-j` for `repo sync` and `mka`)
+ * `PARALLEL_JOBS`: Limit the number of parallel jobs to run (`-j` for `repo sync` and `mka`).
+   By default, the build system should match the number of parallel jobs to the number of cpu
+   cores on your machine. Reducing this number can help keeping it responsive for other tasks.   
 
 The full list of settings, including the less interesting ones not mentioned in
 this guide, can be found in the [Dockerfile][dockerfile].


### PR DESCRIPTION
Adds the option `PARALLEL_JOBS` which can be useful if you want to limit the resources a build job consumes. The value is passed as `-j` argument to the `repo sync` and `mka` commands. If none is specified, probably the number of cpu cores is be used, which can make anything else running on that machine very slow or unusable.

To test from this branch, e.g. for 2 parallel jobs: 

```sh
docker run \
    ...
    -e "PARALLEL_JOBS=2" \
    lineageos4microg/docker-lineage-cicd:limit_parallel_jobs
```