### PR TITLE
Fix TheMuppets repo sync for lineage-20.0

### DIFF
--- a/src/build.sh
+++ b/src/build.sh
@@ -137,7 +137,7 @@ for branch in ${BRANCH_NAME//,/ }; do
         modules_permission_patch="packages_modules_Permission-S.patch"
         ;;
       lineage-20.0*)
-        themuppets_branch="lineage-20"
+        themuppets_branch="lineage-20.0"
         android_version="13"
         frameworks_base_patch="android_frameworks_base-Android13.patch"
         modules_permission_patch="packages_modules_Permission-Android13.patch"

--- a/src/build_manifest.py
+++ b/src/build_manifest.py
@@ -53,6 +53,9 @@ if __name__ == "__main__":
 
             if args.remote:
                 attributes["remote"] = args.remotename
+            
+            if "revision" in child.attrib:
+                attributes["revision"] = child.attrib["revision"]
 
             ET.SubElement(xmlout, 'project', attrib=attributes)
 


### PR DESCRIPTION
TheMuppets branch for the manifest repo is actually "lineage-20.0". But the other repo's branch are "lineage-20" and is specified with the revision attribute in the xml file of the manifest.