### PR TITLE
Resolve the "Hunk n succeeded" warnings

### DIFF
--- a/src/build.sh
+++ b/src/build.sh
@@ -137,7 +137,7 @@ for branch in ${BRANCH_NAME//,/ }; do
         modules_permission_patch="packages_modules_Permission-S.patch"
         ;;
       lineage-20.0*)
-        themuppets_branch="lineage-20.0"
+        themuppets_branch="lineage-20"
         android_version="13"
         frameworks_base_patch="android_frameworks_base-Android13.patch"
         modules_permission_patch="packages_modules_Permission-Android13.patch"

--- a/src/build.sh
+++ b/src/build.sh
@@ -137,7 +137,7 @@ for branch in ${BRANCH_NAME//,/ }; do
         modules_permission_patch="packages_modules_Permission-S.patch"
         ;;
       lineage-20.0*)
-        themuppets_branch="lineage-20"
+        themuppets_branch="lineage-20.0"
         android_version="13"
         frameworks_base_patch="android_frameworks_base-Android13.patch"
         modules_permission_patch="packages_modules_Permission-Android13.patch"

--- a/src/build.sh
+++ b/src/build.sh
@@ -136,8 +136,8 @@ for branch in ${BRANCH_NAME//,/ }; do
         frameworks_base_patch="android_frameworks_base-S.patch"
         modules_permission_patch="packages_modules_Permission-S.patch"
         ;;
-      lineage-20*)
-        themuppets_branch="lineage-20"
+      lineage-20.0*)
+        themuppets_branch="lineage-20.0"
         android_version="13"
         frameworks_base_patch="android_frameworks_base-Android13.patch"
         modules_permission_patch="packages_modules_Permission-Android13.patch"

--- a/src/build.sh
+++ b/src/build.sh
@@ -136,6 +136,12 @@ for branch in ${BRANCH_NAME//,/ }; do
         frameworks_base_patch="android_frameworks_base-S.patch"
         modules_permission_patch="packages_modules_Permission-S.patch"
         ;;
+      lineage-20*)
+        themuppets_branch="lineage-20"
+        android_version="13"
+        frameworks_base_patch="android_frameworks_base-Android13.patch"
+        modules_permission_patch="packages_modules_Permission-Android13.patch"
+        ;;
       *)
         echo ">> [$(date)] Building branch $branch is not (yet) suppported"
         exit 1

--- a/src/build_manifest.py
+++ b/src/build_manifest.py
@@ -53,6 +53,9 @@ if __name__ == "__main__":
 
             if args.remote:
                 attributes["remote"] = args.remotename
+            
+            if "revision" in child.attrib:
+                attributes["revision"] = child.attrib["revision"]
 
             ET.SubElement(xmlout, 'project', attrib=attributes)
 

--- a/src/init.sh
+++ b/src/init.sh
@@ -42,13 +42,21 @@ if [ "$SIGN_BUILDS" = true ]; then
       /root/make_key "$KEYS_DIR/$c" "$KEYS_SUBJECT" <<< '' &> /dev/null
     done
   else
-    for c in releasekey platform shared media networkstack sdk_sandbox bluetooth; do
+    for c in releasekey platform shared media networkstack; do
       for e in pk8 x509.pem; do
         if [ ! -f "$KEYS_DIR/$c.$e" ]; then
           echo ">> [$(date)] SIGN_BUILDS = true and not empty \$KEYS_DIR, but \"\$KEYS_DIR/$c.$e\" is missing"
           exit 1
         fi
       done
+    done
+    
+    # those keys are only required starting with android-20, so people who have built earlier might not yet have them
+    for c in sdk_sandbox bluetooth; do
+      if [ ! -f "$KEYS_DIR/$c.pk8" ]; then
+        echo ">> [$(date)]  Generating $c..."
+        /root/make_key "$KEYS_DIR/$c" "$KEYS_SUBJECT" <<< '' &> /dev/null
+      fi
     done
   fi
 

--- a/src/init.sh
+++ b/src/init.sh
@@ -37,12 +37,12 @@ git config --global user.email "$USER_MAIL"
 if [ "$SIGN_BUILDS" = true ]; then
   if [ -z "$(ls -A "$KEYS_DIR")" ]; then
     echo ">> [$(date)] SIGN_BUILDS = true but empty \$KEYS_DIR, generating new keys"
-    for c in releasekey platform shared media networkstack; do
+    for c in releasekey platform shared media networkstack sdk_sandbox bluetooth; do
       echo ">> [$(date)]  Generating $c..."
       /root/make_key "$KEYS_DIR/$c" "$KEYS_SUBJECT" <<< '' &> /dev/null
     done
   else
-    for c in releasekey platform shared media networkstack; do
+    for c in releasekey platform shared media networkstack sdk_sandbox bluetooth; do
       for e in pk8 x509.pem; do
         if [ ! -f "$KEYS_DIR/$c.$e" ]; then
           echo ">> [$(date)] SIGN_BUILDS = true and not empty \$KEYS_DIR, but \"\$KEYS_DIR/$c.$e\" is missing"

--- a/src/signature_spoofing_patches/android_frameworks_base-Android13.patch
+++ b/src/signature_spoofing_patches/android_frameworks_base-Android13.patch
@@ -1,0 +1,140 @@
+diff --git a/core/api/current.txt b/core/api/current.txt
+index c8a43db2f9c2..cb812f0f0d73 100644
+--- a/core/api/current.txt
++++ b/core/api/current.txt
+@@ -85,6 +85,7 @@ package android {
+     field public static final String DIAGNOSTIC = "android.permission.DIAGNOSTIC";
+     field public static final String DISABLE_KEYGUARD = "android.permission.DISABLE_KEYGUARD";
+     field public static final String DUMP = "android.permission.DUMP";
++    field public static final String FAKE_PACKAGE_SIGNATURE = "android.permission.FAKE_PACKAGE_SIGNATURE";
+     field public static final String EXPAND_STATUS_BAR = "android.permission.EXPAND_STATUS_BAR";
+     field public static final String FACTORY_TEST = "android.permission.FACTORY_TEST";
+     field public static final String FOREGROUND_SERVICE = "android.permission.FOREGROUND_SERVICE";
+@@ -222,6 +223,7 @@ package android {
+     field public static final String CALL_LOG = "android.permission-group.CALL_LOG";
+     field public static final String CAMERA = "android.permission-group.CAMERA";
+     field public static final String CONTACTS = "android.permission-group.CONTACTS";
++    field public static final String FAKE_PACKAGE = "android.permission-group.FAKE_PACKAGE";
+     field public static final String LOCATION = "android.permission-group.LOCATION";
+     field public static final String MICROPHONE = "android.permission-group.MICROPHONE";
+     field public static final String NEARBY_DEVICES = "android.permission-group.NEARBY_DEVICES";
+diff --git a/core/res/AndroidManifest.xml b/core/res/AndroidManifest.xml
+index 6e48de5ba31f..32b0cd346e91 100644
+--- a/core/res/AndroidManifest.xml
++++ b/core/res/AndroidManifest.xml
+@@ -3542,6 +3542,21 @@
+         android:description="@string/permdesc_getPackageSize"
+         android:protectionLevel="normal" />
+ 
++    <!-- Dummy user-facing group for faking package signature -->
++    <permission-group android:name="android.permission-group.FAKE_PACKAGE"
++        android:label="@string/permgrouplab_fake_package_signature"
++        android:description="@string/permgroupdesc_fake_package_signature"
++        android:request="@string/permgrouprequest_fake_package_signature"
++        android:priority="100" />
++
++    <!-- Allows an application to change the package signature as
++         seen by applications -->
++    <permission android:name="android.permission.FAKE_PACKAGE_SIGNATURE"
++        android:permissionGroup="android.permission-group.UNDEFINED"
++        android:protectionLevel="dangerous"
++        android:label="@string/permlab_fakePackageSignature"
++        android:description="@string/permdesc_fakePackageSignature" />
++
+     <!-- @deprecated No longer useful, see
+          {@link android.content.pm.PackageManager#addPackageToPreferred}
+          for details. -->
+diff --git a/core/res/res/values/config.xml b/core/res/res/values/config.xml
+index 34b5589bf81f..fd6507736347 100644
+--- a/core/res/res/values/config.xml
++++ b/core/res/res/values/config.xml
+@@ -1913,6 +1913,8 @@
+     <string-array name="config_locationProviderPackageNames" translatable="false">
+         <!-- The standard AOSP fused location provider -->
+         <item>com.android.location.fused</item>
++        <!-- Google Play Services or microG (free reimplementation) location provider -->
++        <item>com.google.android.gms</item>
+     </string-array>
+ 
+     <!-- Package name(s) of Advanced Driver Assistance applications. These packages have additional
+diff --git a/core/res/res/values/strings.xml b/core/res/res/values/strings.xml
+index e5d90f00f327..7ac26e536f2a 100644
+--- a/core/res/res/values/strings.xml
++++ b/core/res/res/values/strings.xml
+@@ -974,6 +974,18 @@
+ 
+     <!--  Permissions -->
+ 
++    <!-- Title of an application permission, listed so the user can choose whether they want to allow the application to do this. -->
++    <string name="permlab_fakePackageSignature">Spoof package signature</string>
++    <!-- Description of an application permission, listed so the user can choose whether they want to allow the application to do this. -->
++    <string name="permdesc_fakePackageSignature">Allows the app to pretend to be a different app. Malicious applications might be able to use this to access private application data. Legitimate uses include an emulator pretending to be what it emulates. Grant this permission with caution only!</string>
++    <!-- Title of a category of application permissions, listed so the user can choose whether they want to allow the application to do this. -->
++    <string name="permgrouplab_fake_package_signature">Spoof package signature</string>
++    <!-- Description of a category of application permissions, listed so the user can choose whether they want to allow the application to do this. -->
++    <string name="permgroupdesc_fake_package_signature">allow to spoof package signature</string>
++    <!-- Message shown to the user when the apps requests permission from this group. If ever possible this should stay below 80 characters (assuming the parameters takes 20 characters). Don't abbreviate until the message reaches 120 characters though. [CHAR LIMIT=120] -->
++    <string name="permgrouprequest_fake_package_signature">Allow
++        &lt;b><xliff:g id="app_name" example="Gmail">%1$s</xliff:g>&lt;/b> to spoof package signature?</string>
++
+     <!-- Title of an application permission, listed so the user can choose whether they want to allow the application to do this. -->
+     <string name="permlab_statusBar">disable or modify status bar</string>
+     <!-- Description of an application permission, listed so the user can choose whether they want to allow the application to do this. -->
+diff --git a/services/core/java/com/android/server/pm/ComputerEngine.java b/services/core/java/com/android/server/pm/ComputerEngine.java
+index 259ca655d2b9..f78a82b35ef2 100644
+--- a/services/core/java/com/android/server/pm/ComputerEngine.java
++++ b/services/core/java/com/android/server/pm/ComputerEngine.java
+@@ -1591,6 +1591,31 @@ public class ComputerEngine implements Computer {
+         return result;
+     }
+ 
++    private static String getRequestedFakeSignature(AndroidPackage p) {
++        Bundle metaData = p.getMetaData();
++        if (metaData != null) {
++            return metaData.getString("fake-signature");
++        }
++        return null;
++    }
++
++    private static PackageInfo applyFakeSignature(AndroidPackage p, PackageInfo pi,
++            Set<String> permissions) {
++        try {
++            if (permissions.contains("android.permission.FAKE_PACKAGE_SIGNATURE")
++                    && p.getTargetSdkVersion() > Build.VERSION_CODES.LOLLIPOP_MR1) {
++                String sig = getRequestedFakeSignature(p);
++                if (sig != null) {
++                    pi.signatures = new Signature[] { new Signature(sig) };
++                }
++            }
++        } catch (Throwable t) {
++            // We should never die because of any failures, this is system code!
++            Log.w("PackageManagerService.FAKE_PACKAGE_SIGNATURE", t);
++        }
++        return pi;
++    }
++
+     public final PackageInfo generatePackageInfo(PackageStateInternal ps,
+             @PackageManager.PackageInfoFlagsBits long flags, int userId) {
+         if (!mUserManager.exists(userId)) return null;
+@@ -1620,14 +1645,18 @@ public class ComputerEngine implements Computer {
+             final int[] gids = (flags & PackageManager.GET_GIDS) == 0 ? EMPTY_INT_ARRAY
+                     : mPermissionManager.getGidsForUid(UserHandle.getUid(userId, ps.getAppId()));
+             // Compute granted permissions only if package has requested permissions
+-            final Set<String> permissions = ((flags & PackageManager.GET_PERMISSIONS) == 0
+-                    || ArrayUtils.isEmpty(p.getRequestedPermissions())) ? Collections.emptySet()
+-                    : mPermissionManager.getGrantedPermissions(ps.getPackageName(), userId);
++            boolean computePermissions = !ArrayUtils.isEmpty(p.getRequestedPermissions()) &&
++                ((flags & PackageManager.GET_PERMISSIONS) != 0 || getRequestedFakeSignature(p) != null);
++            final Set<String> permissions = computePermissions ?
++                    mPermissionManager.getGrantedPermissions(ps.name, userId)
++                    : Collections.emptySet();
+ 
+             PackageInfo packageInfo = PackageInfoUtils.generate(p, gids, flags,
+                     state.getFirstInstallTime(), ps.getLastUpdateTime(), permissions, state, userId,
+                     ps);
+ 
++            packageInfo = applyFakeSignature(p, packageInfo, permissions);
++
+             if (packageInfo == null) {
+                 return null;
+             }

--- a/src/signature_spoofing_patches/android_frameworks_base-Android13.patch
+++ b/src/signature_spoofing_patches/android_frameworks_base-Android13.patch
@@ -67,7 +67,7 @@ diff --git a/core/res/res/values/strings.xml b/core/res/res/values/strings.xml
 diff --git a/services/core/java/com/android/server/pm/ComputerEngine.java b/services/core/java/com/android/server/pm/ComputerEngine.java
 --- a/services/core/java/com/android/server/pm/ComputerEngine.java
 +++ b/services/core/java/com/android/server/pm/ComputerEngine.java
-@@ -1591,6 +1591,29 @@ public class ComputerEngine implements Computer {
+@@ -1603,6 +1603,29 @@ public class ComputerEngine implements Computer {
          return result;
      }
  
@@ -97,7 +97,7 @@ diff --git a/services/core/java/com/android/server/pm/ComputerEngine.java b/serv
      public final PackageInfo generatePackageInfo(PackageStateInternal ps,
              @PackageManager.PackageInfoFlagsBits long flags, int userId) {
          if (!mUserManager.exists(userId)) return null;
-@@ -1620,13 +1643,15 @@ public class ComputerEngine implements Computer {
+@@ -1632,13 +1655,15 @@ public class ComputerEngine implements Computer {
              final int[] gids = (flags & PackageManager.GET_GIDS) == 0 ? EMPTY_INT_ARRAY
                      : mPermissionManager.getGidsForUid(UserHandle.getUid(userId, ps.getAppId()));
              // Compute granted permissions only if package has requested permissions

--- a/src/signature_spoofing_patches/android_frameworks_base-Android13.patch
+++ b/src/signature_spoofing_patches/android_frameworks_base-Android13.patch
@@ -1,15 +1,14 @@
 diff --git a/core/api/current.txt b/core/api/current.txt
-index c8a43db2f9c2..cb812f0f0d73 100644
 --- a/core/api/current.txt
 +++ b/core/api/current.txt
-@@ -85,6 +85,7 @@ package android {
-     field public static final String DIAGNOSTIC = "android.permission.DIAGNOSTIC";
-     field public static final String DISABLE_KEYGUARD = "android.permission.DISABLE_KEYGUARD";
+@@ -87,6 +87,7 @@ package android {
      field public static final String DUMP = "android.permission.DUMP";
-+    field public static final String FAKE_PACKAGE_SIGNATURE = "android.permission.FAKE_PACKAGE_SIGNATURE";
      field public static final String EXPAND_STATUS_BAR = "android.permission.EXPAND_STATUS_BAR";
      field public static final String FACTORY_TEST = "android.permission.FACTORY_TEST";
++    field public static final String FAKE_PACKAGE_SIGNATURE = "android.permission.FAKE_PACKAGE_SIGNATURE";
      field public static final String FOREGROUND_SERVICE = "android.permission.FOREGROUND_SERVICE";
+     field public static final String GET_ACCOUNTS = "android.permission.GET_ACCOUNTS";
+     field public static final String GET_ACCOUNTS_PRIVILEGED = "android.permission.GET_ACCOUNTS_PRIVILEGED";
 @@ -222,6 +223,7 @@ package android {
      field public static final String CALL_LOG = "android.permission-group.CALL_LOG";
      field public static final String CAMERA = "android.permission-group.CAMERA";
@@ -19,7 +18,6 @@ index c8a43db2f9c2..cb812f0f0d73 100644
      field public static final String MICROPHONE = "android.permission-group.MICROPHONE";
      field public static final String NEARBY_DEVICES = "android.permission-group.NEARBY_DEVICES";
 diff --git a/core/res/AndroidManifest.xml b/core/res/AndroidManifest.xml
-index 6e48de5ba31f..32b0cd346e91 100644
 --- a/core/res/AndroidManifest.xml
 +++ b/core/res/AndroidManifest.xml
 @@ -3542,6 +3542,21 @@
@@ -44,21 +42,7 @@ index 6e48de5ba31f..32b0cd346e91 100644
      <!-- @deprecated No longer useful, see
           {@link android.content.pm.PackageManager#addPackageToPreferred}
           for details. -->
-diff --git a/core/res/res/values/config.xml b/core/res/res/values/config.xml
-index 34b5589bf81f..fd6507736347 100644
---- a/core/res/res/values/config.xml
-+++ b/core/res/res/values/config.xml
-@@ -1913,6 +1913,8 @@
-     <string-array name="config_locationProviderPackageNames" translatable="false">
-         <!-- The standard AOSP fused location provider -->
-         <item>com.android.location.fused</item>
-+        <!-- Google Play Services or microG (free reimplementation) location provider -->
-+        <item>com.google.android.gms</item>
-     </string-array>
- 
-     <!-- Package name(s) of Advanced Driver Assistance applications. These packages have additional
 diff --git a/core/res/res/values/strings.xml b/core/res/res/values/strings.xml
-index e5d90f00f327..7ac26e536f2a 100644
 --- a/core/res/res/values/strings.xml
 +++ b/core/res/res/values/strings.xml
 @@ -974,6 +974,18 @@
@@ -81,29 +65,26 @@ index e5d90f00f327..7ac26e536f2a 100644
      <string name="permlab_statusBar">disable or modify status bar</string>
      <!-- Description of an application permission, listed so the user can choose whether they want to allow the application to do this. -->
 diff --git a/services/core/java/com/android/server/pm/ComputerEngine.java b/services/core/java/com/android/server/pm/ComputerEngine.java
-index 259ca655d2b9..f78a82b35ef2 100644
 --- a/services/core/java/com/android/server/pm/ComputerEngine.java
 +++ b/services/core/java/com/android/server/pm/ComputerEngine.java
-@@ -1591,6 +1591,31 @@ public class ComputerEngine implements Computer {
+@@ -1591,6 +1591,29 @@ public class ComputerEngine implements Computer {
          return result;
      }
  
-+    private static String getRequestedFakeSignature(AndroidPackage p) {
-+        Bundle metaData = p.getMetaData();
-+        if (metaData != null) {
-+            return metaData.getString("fake-signature");
-+        }
-+        return null;
++    private boolean requestsFakeSignature(AndroidPackage p) {
++        return p.getMetaData() != null &&
++                p.getMetaData().getString("fake-signature") != null;
 +    }
 +
-+    private static PackageInfo applyFakeSignature(AndroidPackage p, PackageInfo pi,
++    private PackageInfo mayFakeSignature(AndroidPackage p, PackageInfo pi,
 +            Set<String> permissions) {
 +        try {
-+            if (permissions.contains("android.permission.FAKE_PACKAGE_SIGNATURE")
-+                    && p.getTargetSdkVersion() > Build.VERSION_CODES.LOLLIPOP_MR1) {
-+                String sig = getRequestedFakeSignature(p);
-+                if (sig != null) {
-+                    pi.signatures = new Signature[] { new Signature(sig) };
++            if (p.getMetaData() != null &&
++                    p.getTargetSdkVersion() > Build.VERSION_CODES.LOLLIPOP_MR1) {
++                String sig = p.getMetaData().getString("fake-signature");
++                if (sig != null &&
++                        permissions.contains("android.permission.FAKE_PACKAGE_SIGNATURE")) {
++                    pi.signatures = new Signature[] {new Signature(sig)};
 +                }
 +            }
 +        } catch (Throwable t) {
@@ -116,25 +97,22 @@ index 259ca655d2b9..f78a82b35ef2 100644
      public final PackageInfo generatePackageInfo(PackageStateInternal ps,
              @PackageManager.PackageInfoFlagsBits long flags, int userId) {
          if (!mUserManager.exists(userId)) return null;
-@@ -1620,14 +1645,18 @@ public class ComputerEngine implements Computer {
+@@ -1620,13 +1643,15 @@ public class ComputerEngine implements Computer {
              final int[] gids = (flags & PackageManager.GET_GIDS) == 0 ? EMPTY_INT_ARRAY
                      : mPermissionManager.getGidsForUid(UserHandle.getUid(userId, ps.getAppId()));
              // Compute granted permissions only if package has requested permissions
 -            final Set<String> permissions = ((flags & PackageManager.GET_PERMISSIONS) == 0
--                    || ArrayUtils.isEmpty(p.getRequestedPermissions())) ? Collections.emptySet()
--                    : mPermissionManager.getGrantedPermissions(ps.getPackageName(), userId);
-+            boolean computePermissions = !ArrayUtils.isEmpty(p.getRequestedPermissions()) &&
-+                ((flags & PackageManager.GET_PERMISSIONS) != 0 || getRequestedFakeSignature(p) != null);
-+            final Set<String> permissions = computePermissions ?
-+                    mPermissionManager.getGrantedPermissions(ps.name, userId)
-+                    : Collections.emptySet();
++            final Set<String> permissions = (((flags & PackageManager.GET_PERMISSIONS) == 0
++                        && !requestsFakeSignature(p))
+                     || ArrayUtils.isEmpty(p.getRequestedPermissions())) ? Collections.emptySet()
+                     : mPermissionManager.getGrantedPermissions(ps.getPackageName(), userId);
  
-             PackageInfo packageInfo = PackageInfoUtils.generate(p, gids, flags,
+-            PackageInfo packageInfo = PackageInfoUtils.generate(p, gids, flags,
++            PackageInfo packageInfo = mayFakeSignature(p, PackageInfoUtils.generate(p, gids, flags,
                      state.getFirstInstallTime(), ps.getLastUpdateTime(), permissions, state, userId,
-                     ps);
+-                    ps);
++                    ps),
++                    permissions);
  
-+            packageInfo = applyFakeSignature(p, packageInfo, permissions);
-+
              if (packageInfo == null) {
                  return null;
-             }

--- a/src/signature_spoofing_patches/packages_modules_Permission-Android13.patch
+++ b/src/signature_spoofing_patches/packages_modules_Permission-Android13.patch
@@ -1,0 +1,21 @@
+diff --git a/PermissionController/src/com/android/permissioncontroller/permission/utils/Utils.java b/PermissionController/src/com/android/permissioncontroller/permission/utils/Utils.java
+index 48793ab51..d75a58360 100644
+--- a/PermissionController/src/com/android/permissioncontroller/permission/utils/Utils.java
++++ b/PermissionController/src/com/android/permissioncontroller/permission/utils/Utils.java
+@@ -21,6 +21,7 @@ import static android.Manifest.permission_group.CALENDAR;
+ import static android.Manifest.permission_group.CALL_LOG;
+ import static android.Manifest.permission_group.CAMERA;
+ import static android.Manifest.permission_group.CONTACTS;
++import static android.Manifest.permission_group.FAKE_PACKAGE;
+ import static android.Manifest.permission_group.LOCATION;
+ import static android.Manifest.permission_group.MICROPHONE;
+ import static android.Manifest.permission_group.NEARBY_DEVICES;
+@@ -341,6 +342,8 @@ public final class Utils {
+             PLATFORM_PERMISSIONS.put(Manifest.permission.BODY_SENSORS_BACKGROUND, SENSORS);
+         }
+ 
++        PLATFORM_PERMISSIONS.put(Manifest.permission.FAKE_PACKAGE_SIGNATURE, FAKE_PACKAGE);
++
+         PLATFORM_PERMISSION_GROUPS = new ArrayMap<>();
+         int numPlatformPermissions = PLATFORM_PERMISSIONS.size();
+         for (int i = 0; i < numPlatformPermissions; i++) {


### PR DESCRIPTION
Resolve the "Hunk n succeeded" warnings, and to prevent generating the `.orig` files.
```
patching file core/api/current.txt
patching file core/res/AndroidManifest.xml
patching file core/res/res/values/strings.xml
patching file services/core/java/com/android/server/pm/ComputerEngine.java
Hunk #1 succeeded at 1603 (offset 12 lines).
Hunk #2 succeeded at 1655 (offset 12 lines).
```