### PR TITLE
20.0: Resolve the "Hunk n succeeded" warnings once again

### DIFF
--- a/src/signature_spoofing_patches/android_frameworks_base-Android13.patch
+++ b/src/signature_spoofing_patches/android_frameworks_base-Android13.patch
@@ -1,4 +1,5 @@
 diff --git a/core/api/current.txt b/core/api/current.txt
+index 487e57d114c9..04e69741b9fd 100644
 --- a/core/api/current.txt
 +++ b/core/api/current.txt
 @@ -87,6 +87,7 @@ package android {
@@ -18,9 +19,10 @@ diff --git a/core/api/current.txt b/core/api/current.txt
      field public static final String MICROPHONE = "android.permission-group.MICROPHONE";
      field public static final String NEARBY_DEVICES = "android.permission-group.NEARBY_DEVICES";
 diff --git a/core/res/AndroidManifest.xml b/core/res/AndroidManifest.xml
+index bbe31240f5f3..44858c02f058 100644
 --- a/core/res/AndroidManifest.xml
 +++ b/core/res/AndroidManifest.xml
-@@ -3542,6 +3542,21 @@
+@@ -3572,6 +3572,21 @@
          android:description="@string/permdesc_getPackageSize"
          android:protectionLevel="normal" />
  
@@ -43,9 +45,10 @@ diff --git a/core/res/AndroidManifest.xml b/core/res/AndroidManifest.xml
           {@link android.content.pm.PackageManager#addPackageToPreferred}
           for details. -->
 diff --git a/core/res/res/values/strings.xml b/core/res/res/values/strings.xml
+index 9410e0682106..7ed7a03f1b61 100644
 --- a/core/res/res/values/strings.xml
 +++ b/core/res/res/values/strings.xml
-@@ -974,6 +974,18 @@
+@@ -977,6 +977,18 @@
  
      <!--  Permissions -->
  
@@ -65,6 +68,7 @@ diff --git a/core/res/res/values/strings.xml b/core/res/res/values/strings.xml
      <string name="permlab_statusBar">disable or modify status bar</string>
      <!-- Description of an application permission, listed so the user can choose whether they want to allow the application to do this. -->
 diff --git a/services/core/java/com/android/server/pm/ComputerEngine.java b/services/core/java/com/android/server/pm/ComputerEngine.java
+index 46b7460dff1b..90f75dedef59 100644
 --- a/services/core/java/com/android/server/pm/ComputerEngine.java
 +++ b/services/core/java/com/android/server/pm/ComputerEngine.java
 @@ -1603,6 +1603,29 @@ public class ComputerEngine implements Computer {


### PR DESCRIPTION
Resolve the "Hunk n succeeded" warnings, and to prevent generating `.orig` files
```
patching file core/api/current.txt
patching file core/res/AndroidManifest.xml
Hunk #1 succeeded at 3572 (offset 30 lines).
patching file core/res/res/values/strings.xml
Hunk #1 succeeded at 977 (offset 3 lines).
patching file services/core/java/com/android/server/pm/ComputerEngine.java
```