### PR TITLE
update Updater app strings.xml file

### DIFF
--- a/src/build.sh
+++ b/src/build.sh
@@ -249,13 +249,13 @@ for branch in ${BRANCH_NAME//,/ }; do
     # Set a custom updater URI if a OTA URL is provided
     echo ">> [$(date)] Adding OTA URL overlay (for custom URL $OTA_URL)"
     if [ -n "$OTA_URL" ]; then
-      updater_url_overlay_dir="vendor/$vendor/overlay/microg/packages/apps/Updater/res/values/"
+      updater_url_overlay_dir="vendor/$vendor/overlay/microg/packages/apps/Updater/app/src/main/res/values/"
       mkdir -p "$updater_url_overlay_dir"
 
-      if grep -q updater_server_url packages/apps/Updater/res/values/strings.xml; then
+      if grep -q updater_server_url packages/apps/Updater/app/src/main/res/values/strings.xml; then
         # "New" updater configuration: full URL (with placeholders {device}, {type} and {incr})
         sed "s|{name}|updater_server_url|g; s|{url}|$OTA_URL/v1/{device}/{type}/{incr}|g" /root/packages_updater_strings.xml > "$updater_url_overlay_dir/strings.xml"
-      elif grep -q conf_update_server_url_def packages/apps/Updater/res/values/strings.xml; then
+      elif grep -q conf_update_server_url_def packages/apps/Updater/app/src/main/res/values/strings.xml; then
         # "Old" updater configuration: just the URL
         sed "s|{name}|conf_update_server_url_def|g; s|{url}|$OTA_URL|g" /root/packages_updater_strings.xml > "$updater_url_overlay_dir/strings.xml"
       else


### PR DESCRIPTION
Hi

The Updater app have changed the project structure on this commit
https://github.com/LineageOS/android_packages_apps_Updater/commit/755560bbcddb9ef52f1368185d52e019d1cba37a
that was merged on lineage-20.0 branch on 8th july
https://github.com/LineageOS/android_packages_apps_Updater/commits/lineage-20.0

I update the build.sh script to set the new location for the values file
fix #443 


