### PR TITLE
Handle build failures better

### DIFF
--- a/src/build.sh
+++ b/src/build.sh
@@ -370,7 +370,7 @@ for branch in ${BRANCH_NAME//,/ }; do
             mv "$build" "$ZIP_DIR/$zipsubdir/" &>> "$DEBUG_LOG"
             files_to_hash+=( "$build" )
           done
-          for image in recovery boot vendor_boot; do
+          for image in recovery boot vendor_boot dtbo super_empty vbmeta; do
             if [ -f "$image.img" ]; then
               recovery_name="lineage-$los_ver-$builddate-$RELEASE_TYPE-$codename-$image.img"
               cp "$image.img" "$ZIP_DIR/$zipsubdir/$recovery_name" &>> "$DEBUG_LOG"

--- a/src/build.sh
+++ b/src/build.sh
@@ -346,7 +346,7 @@ for branch in ${BRANCH_NAME//,/ }; do
             # call post-build.sh so the failure is logged in a way that is more visible
             if [ -f /root/userscripts/post-build.sh ]; then
               echo ">> [$(date)] Running post-build.sh for $codename" >> "$DEBUG_LOG"
-              /root/userscripts/post-build.sh "$codename $branch $build_successful" &>> "$DEBUG_LOG" || echo ">> [$(date)] Warning: post-build.sh failed!"
+              /root/userscripts/post-build.sh "$codename false $branch" &>> "$DEBUG_LOG" || echo ">> [$(date)] Warning: post-build.sh failed!"
             fi
             continue
         fi
@@ -404,7 +404,7 @@ for branch in ${BRANCH_NAME//,/ }; do
         fi
         if [ -f /root/userscripts/post-build.sh ]; then
           echo ">> [$(date)] Running post-build.sh for $codename" >> "$DEBUG_LOG"
-          /root/userscripts/post-build.sh "$codename $branch" $build_successful &>> "$DEBUG_LOG" || echo ">> [$(date)] Warning: post-build.sh failed!"
+          /root/userscripts/post-build.sh "$codename  $build_successful $branch" &>> "$DEBUG_LOG" || echo ">> [$(date)] Warning: post-build.sh failed!"
         fi
         echo ">> [$(date)] Finishing build for $codename" | tee -a "$DEBUG_LOG"
 

--- a/src/build.sh
+++ b/src/build.sh
@@ -399,7 +399,7 @@ for branch in ${BRANCH_NAME//,/ }; do
         fi
         if [ -f /root/userscripts/post-build.sh ]; then
           echo ">> [$(date)] Running post-build.sh for $codename" >> "$DEBUG_LOG"
-          /root/userscripts/post-build.sh "$codename" $build_successful &>> "$DEBUG_LOG" || echo ">> [$(date)] Warning: post-build.sh failed!"
+          /root/userscripts/post-build.sh "$codename $branch" $build_successful &>> "$DEBUG_LOG" || echo ">> [$(date)] Warning: post-build.sh failed!"
         fi
         echo ">> [$(date)] Finishing build for $codename" | tee -a "$DEBUG_LOG"
 

--- a/src/build.sh
+++ b/src/build.sh
@@ -343,6 +343,11 @@ for branch in ${BRANCH_NAME//,/ }; do
         set -eu
         if [ $breakfast_returncode -ne 0 ]; then
             echo ">> [$(date)] breakfast failed for $codename, $branch branch" | tee -a "$DEBUG_LOG"
+            # call post-build.sh so the failure is logged in a way that is more visible
+            if [ -f /root/userscripts/post-build.sh ]; then
+              echo ">> [$(date)] Running post-build.sh for $codename" >> "$DEBUG_LOG"
+              /root/userscripts/post-build.sh "$codename $branch" $build_successful &>> "$DEBUG_LOG" || echo ">> [$(date)] Warning: post-build.sh failed!"
+            fi
             continue
         fi
 

--- a/src/build.sh
+++ b/src/build.sh
@@ -346,7 +346,7 @@ for branch in ${BRANCH_NAME//,/ }; do
             # call post-build.sh so the failure is logged in a way that is more visible
             if [ -f /root/userscripts/post-build.sh ]; then
               echo ">> [$(date)] Running post-build.sh for $codename" >> "$DEBUG_LOG"
-              /root/userscripts/post-build.sh "$codename $branch" $build_successful &>> "$DEBUG_LOG" || echo ">> [$(date)] Warning: post-build.sh failed!"
+              /root/userscripts/post-build.sh "$codename $branch $build_successful" &>> "$DEBUG_LOG" || echo ">> [$(date)] Warning: post-build.sh failed!"
             fi
             continue
         fi

--- a/src/build.sh
+++ b/src/build.sh
@@ -346,7 +346,7 @@ for branch in ${BRANCH_NAME//,/ }; do
             # call post-build.sh so the failure is logged in a way that is more visible
             if [ -f /root/userscripts/post-build.sh ]; then
               echo ">> [$(date)] Running post-build.sh for $codename" >> "$DEBUG_LOG"
-              /root/userscripts/post-build.sh "$codename false $branch" &>> "$DEBUG_LOG" || echo ">> [$(date)] Warning: post-build.sh failed!"
+              /root/userscripts/post-build.sh "$codename" false "$branch" &>> "$DEBUG_LOG" || echo ">> [$(date)] Warning: post-build.sh failed!"
             fi
             continue
         fi
@@ -404,7 +404,7 @@ for branch in ${BRANCH_NAME//,/ }; do
         fi
         if [ -f /root/userscripts/post-build.sh ]; then
           echo ">> [$(date)] Running post-build.sh for $codename" >> "$DEBUG_LOG"
-          /root/userscripts/post-build.sh "$codename  $build_successful $branch" &>> "$DEBUG_LOG" || echo ">> [$(date)] Warning: post-build.sh failed!"
+          /root/userscripts/post-build.sh "$codename" $build_successful "$branch" &>> "$DEBUG_LOG" || echo ">> [$(date)] Warning: post-build.sh failed!"
         fi
         echo ">> [$(date)] Finishing build for $codename" | tee -a "$DEBUG_LOG"
 


### PR DESCRIPTION
This fixes #450 
- `post-build.sh` will be called if `breakfast` fails, meaning these build failures will be more visible, and will be reported in the matrix channel
- `$branch` is passed in the call to `post-build.sh`, allowing us to log build failures in build-specific files, so that they can be addressed - manually or automatically - once a monthly build run is complete