### PR TITLE
Add `WITH_MICROG` setting 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -93,6 +93,9 @@ ENV ZIP_SUBDIR true
 # Write the verbose logs to $LOGS_DIR/$codename instead of $LOGS_DIR/
 ENV LOGS_SUBDIR true
 
+# Include microG's components in the ROM
+ENV WITH_MICROG false
+
 # Apply the MicroG's signature spoofing patch
 # Valid values are "no", "yes" (for the original MicroG's patch) and
 # "restricted" (to grant the permission only to the system privileged apps).

--- a/README.md
+++ b/README.md
@@ -54,13 +54,12 @@ the list of devices for each specific branch (see [the examples](#examples)).
 
 ### GMS / microG
 
-To include microG (or possibly the actual Google Mobile Services) in your build,
-LineageOS expects certain Makefiles in `vendor/partner_gms` and variable
-`WITH_GMS` set to `true`.
+To include microG's components in your build, you must provide the components
+in `vendor/partner_gms` and set variable `WITH_MICROG` to `true`.
 
 [This][android_vendor_partner_gms] repo contains the common packages included for
-official lineageos4microg builds. To include it in your build, create an XML
-(the name is irrelevant, as long as it ends with `.xml`) in the
+official lineageos4microg builds. To include it in your build, create a `microg.xml`
+file (the name is irrelevant as long as it ends with `.xml`) in the
 `/home/user/manifests` folder with this content:
 
 ```xml
@@ -69,6 +68,9 @@ official lineageos4microg builds. To include it in your build, create an XML
     <project path="vendor/partner_gms" name="lineageos4microg/android_vendor_partner_gms" remote="github" revision="master" />
 </manifest>
 ```
+
+To include the actual Google Mobile Services in your build instead, provide
+those components in `vendor/partner_gms` and set variable `WITH_GMS` to `true`.
 
 ### Additional custom apps
 
@@ -231,7 +233,7 @@ docker run \
     -e "DEVICE_LIST=bacon" \
     -e "SIGN_BUILDS=true" \
     -e "SIGNATURE_SPOOFING=restricted" \
-    -e "WITH_GMS=true" \
+    -e "WITH_MICROG=true" \
     -v "/home/user/lineage:/srv/src" \
     -v "/home/user/zips:/srv/zips" \
     -v "/home/user/logs:/srv/logs" \
@@ -258,7 +260,7 @@ docker run \
     -e "DEVICE_LIST_LINEAGE_18_1=river,lake" \
     -e "SIGN_BUILDS=true" \
     -e "SIGNATURE_SPOOFING=restricted" \
-    -e "WITH_GMS=true" \
+    -e "WITH_MICROG=true" \
     -e "OTA_URL=https://api.myserver.com/" \
     -v "/home/user/lineage:/srv/src" \
     -v "/home/user/zips:/srv/zips" \
@@ -319,7 +321,7 @@ docker run \
     -e "DEVICE_LIST=a6000" \
     -e "SIGN_BUILDS=true" \
     -e "SIGNATURE_SPOOFING=restricted" \
-    -e "WITH_GMS=true" \
+    -e "WITH_MICROG=true" \
     -e "INCLUDE_PROPRIETARY=false" \
     -v "/home/user/lineage:/srv/src" \
     -v "/home/user/zips:/srv/zips" \

--- a/src/build.sh
+++ b/src/build.sh
@@ -211,13 +211,6 @@ for branch in ${BRANCH_NAME//,/ }; do
     if [ "$WITH_MICROG" = true ]; then
       echo '$(call inherit-product, vendor/partner_gms/products/gms.mk)' > "vendor/$vendor/config/partner_gms.mk"
     fi
-    if [ "$WITH_GMS" = true ]; then
-      if [ "$WITH_MICROG" = true ]; then
-        echo ">> [$(date)] WARNING: free space for addons be will not be reserved when both WITH_MICROG and WITH_GMS are enabled"
-      else
-        echo ">> [$(date)] WARNING: WITH_GMS will not reserve free space for addons and is deprecated in favor of WITH_MICROG"
-      fi
-    fi
 
     # If needed, apply the microG's signature spoofing patch
     if [ "$SIGNATURE_SPOOFING" = "yes" ] || [ "$SIGNATURE_SPOOFING" = "restricted" ]; then

--- a/src/build.sh
+++ b/src/build.sh
@@ -211,6 +211,13 @@ for branch in ${BRANCH_NAME//,/ }; do
     if [ "$WITH_MICROG" = true ]; then
       echo '$(call inherit-product, vendor/partner_gms/products/gms.mk)' > "vendor/$vendor/config/partner_gms.mk"
     fi
+    if [ "$WITH_GMS" = true ]; then
+      if [ "$WITH_MICROG" = true ]; then
+        echo ">> [$(date)] WARNING: free space for addons be will not be reserved when both WITH_MICROG and WITH_GMS are enabled"
+      else
+        echo ">> [$(date)] WARNING: WITH_GMS will not reserve free space for addons and is deprecated in favor of WITH_MICROG"
+      fi
+    fi
 
     # If needed, apply the microG's signature spoofing patch
     if [ "$SIGNATURE_SPOOFING" = "yes" ] || [ "$SIGNATURE_SPOOFING" = "restricted" ]; then

--- a/src/build.sh
+++ b/src/build.sh
@@ -207,6 +207,11 @@ for branch in ${BRANCH_NAME//,/ }; do
     los_ver_minor=$(sed -n -e 's/^\s*PRODUCT_VERSION_MINOR = //p' "$makefile_containing_version")
     los_ver="$los_ver_major.$los_ver_minor"
 
+    # If needed, include microG's components
+    if [ "$WITH_MICROG" = true ]; then
+      echo '$(call inherit-product, vendor/partner_gms/products/gms.mk)' > "vendor/$vendor/config/partner_gms.mk"
+    fi
+
     # If needed, apply the microG's signature spoofing patch
     if [ "$SIGNATURE_SPOOFING" = "yes" ] || [ "$SIGNATURE_SPOOFING" = "restricted" ]; then
       # Determine which patch should be applied to the current Android source tree


### PR DESCRIPTION
Introduce `WITH_MICROG` to replace use of `WITH_GMS`. Fixes #358.

**PLEASE NOTE:** i don't know the first thing about docker, so i didn't test this at all: i wouldn't know how to. so this might work or not, somebody else would have to test.

clearly builds not having spare space is causing many issues. there was discussions of configuring the extra space manually, which for me makes a lot of sense. unfortunately for blind batch building, it's hard to know how much spare space to allocate for each device. this patch sidesteps the issue by using whatever LOS uses (but after adding microG; hopefully it's small enough to not cause overflows).

in addition to this patch, maybe a specific setting could be added which would allow overriding the default extra space with an exact value. los4mg official builds wouldn't use it, but others might.