### PR TITLE
Add `WITH_GMS_ALT` setting as an alternative to `WITH_GMS`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -93,6 +93,20 @@ ENV ZIP_SUBDIR true
 # Write the verbose logs to $LOGS_DIR/$codename instead of $LOGS_DIR/
 ENV LOGS_SUBDIR true
 
+# Include microG's components in the ROM
+ENV WITH_GMS false
+
+# Include microG's components in the ROM providing free space for add-ons in system
+#
+# On newer devices running Android 10+ and using dynamic partitions, the size of
+# the system partition is defined by the ROM being flashed. For these devices,
+# regular LineageOS builds reserve some free space in the system partition
+# for add-ons such as GApps (typically 600MB). However, using WITH_GMS to include
+# microG's components in the ROM has the side effect of disabling this space
+# reservation, making later installation of add-ons impossible. Use WITH_GMS_ALT
+# as an alternative to WITH_GMS that does not disable space reservation in system.
+ENV WITH_GMS_ALT false
+
 # Apply the MicroG's signature spoofing patch
 # Valid values are "no", "yes" (for the original MicroG's patch) and
 # "restricted" (to grant the permission only to the system privileged apps).

--- a/src/build.sh
+++ b/src/build.sh
@@ -207,6 +207,16 @@ for branch in ${BRANCH_NAME//,/ }; do
     los_ver_minor=$(sed -n -e 's/^\s*PRODUCT_VERSION_MINOR = //p' "$makefile_containing_version")
     los_ver="$los_ver_major.$los_ver_minor"
 
+    # If needed, include microG's components while providing free space for add-ons in system
+    if [ "$WITH_GMS_ALT" = true ]; then
+      if [ "$WITH_GMS" = true ]; then
+        echo ">> [$(date)] ERROR: WITH_GMS and WITH_GMS_ALT cannot be both true"
+        exit 1
+      else
+        echo '$(call inherit-product, vendor/partner_gms/products/gms.mk)' > "vendor/$vendor/config/partner_gms.mk"
+      fi
+    fi
+
     # If needed, apply the microG's signature spoofing patch
     if [ "$SIGNATURE_SPOOFING" = "yes" ] || [ "$SIGNATURE_SPOOFING" = "restricted" ]; then
       # Determine which patch should be applied to the current Android source tree


### PR DESCRIPTION
> NOTE: this patch is long overdue. i did not post it before because, for reasons affecting LineageOS (not L4M), builds for my device were failing. this has now been fixed upstream so i could properly test everything before creating this PR.

hi @petefoth,

the issue of many L4M builds not having free space in the system partition for add-ons was widely discussed. the cause of the problem is known and fixes were proposed.

but the position of this project is that maintainers do not have the resources/motivation to test a change that affects all builds.

fine, i get that, and there is no possible counter-argument to that.

### however...

as evidenced in previous, somewhat heated talks, many users are still in need of a solution.

here i am proposing one: do not change the way official builds are made, nor the default behavior of this docker, but still let users build their own images with free space for add-ons if they so choose. and let them do this without the hassle of having to fork and build their own docker.

if any such unsupported builds were to fail (they should not, but if) it is entirely their problem, and their time and effort to fix them. i think this is a reasonable solution that still respects the wishes of the project maintainers regarding their resources.

### which devices are affected by this issue?

android 10+ devices that use [dynamic partitions](https://source.android.com/docs/core/ota/dynamic_partitions). because dynamic partitions seriously simplify the lives of OEMs and have no drawbacks, i think it is safe to say that virtually all newer devices will be affected.

### how is this patch used?

you use `WITH_GMS_ALT=true` instead of `WITH_GMS=true`:

- `WITH_GMS_ALT=true` on devices using dynamic partitions causes some free space to be reserved in system. the exact reserved amount is device-specific, but in most if not all affected devices, it is 600MB. (this number will grow in future android versions when gapps growth requires it.)

- `WITH_GMS_ALT=true` on devices _not_ using dynamic partitions behaves exactly like `WITH_GMS=true`.

### example of use

on [OnePlus 8 Pro](https://wiki.lineageos.org/devices/instantnoodlep/), building with `WITH_GMS=true` produces:

```
OnePlus8Pro:/ # mount | grep '/ '                                                                                                                                                                                                            
/dev/block/dm-7 on / type ext4 (ro,seclabel,relatime,discard)
OnePlus8Pro:/ # df -h /                                                                                                                                                                                                                      
Filesystem      Size Used Avail Use% Mounted on
/dev/block/dm-7 824M 821M  2.5M 100% /
```
while building with `WITH_GMS_ALT=true` produces:

```
OnePlus8Pro:/ # mount | grep '/ ' 
/dev/block/dm-7 on / type ext4 (ro,seclabel,relatime,discard)
OnePlus8Pro:/ # df -h / 
Filesystem      Size Used Avail Use% Mounted on
/dev/block/dm-7 1.3G 821M  604M  58% /
```

showing the expected 600MB increment in free space.

### one final note

this patch reports an error if both `WITH_GMS_ALT=true` and `WITH_GMS=true` are set because i have no better way to handle the condition:

```
>> [Sat Oct 14 06:27:49 UTC 2023] Copying '/srv/local_manifests/*.xml' to '.repo/local_manifests/'
>> [Sat Oct 14 06:27:49 UTC 2023] Syncing mirror repository
>> [Sat Oct 14 06:29:56 UTC 2023] Branch:  lineage-20.0
>> [Sat Oct 14 06:29:56 UTC 2023] Devices: instantnoodlep,
>> [Sat Oct 14 06:29:58 UTC 2023] (Re)initializing branch repository
>> [Sat Oct 14 06:29:59 UTC 2023] Copying '/srv/local_manifests/*.xml' to '.repo/local_manifests/'
>> [Sat Oct 14 06:29:59 UTC 2023] Syncing branch repository
>> [Sat Oct 14 06:30:44 UTC 2023] ERROR: WITH_GMS and WITH_GMS_ALT cannot be both true
```

to this effect, the script needs to check for `WITH_GMS` being true. naive checking causes an error if accessing an undefined variable, so the tidiest solution was to add [these lines](https://github.com/Lanchon/docker-lineage-cicd/blob/141acfb1c464015c925afe716406b9b6f869e6e0/Dockerfile#L96-L97).

note that:

- this change cannot affect official builds, because all official builds are done with `WITH_GMS=true`.

- this change cannot affect unofficial builds in which `WITH_GMS` is undefined, because `WITH_GMS` is tested exclusively via `ifeq ($(WITH_GMS),true)` and `ifneq ($(WITH_GMS),true)` statements in LineageOS (which means that `false` behaves the same way as undefined).

however, if [these lines](https://github.com/Lanchon/docker-lineage-cicd/blob/141acfb1c464015c925afe716406b9b6f869e6e0/Dockerfile#L96-L97) are still considered an undue risk, the lines and the detection of concurrent use of `WITH_GMS_ALT=true` and `WITH_GMS=true` can simply be eliminated.

### references

https://github.com/lineageos4microg/docker-lineage-cicd/issues/358
https://github.com/lineageos4microg/docker-lineage-cicd/issues/314
https://github.com/lineageos4microg/docker-lineage-cicd/issues/486
https://github.com/lineageos4microg/docker-lineage-cicd/pull/460

thank you for your help!