### PR TITLE
Restore A14 patches (not working), fix user patch

### DIFF
--- a/src/build.sh
+++ b/src/build.sh
@@ -194,6 +194,8 @@ for branch in ${BRANCH_NAME//,/ }; do
       lineage-21.0*)
         themuppets_branch="lineage-21.0"
         android_version="14"
+        frameworks_base_patch="android_frameworks_base-Android14.patch"
+        modules_permission_patch="packages_modules_Permission-Android14.patch"
         user_build_spoofing_patch="android_frameworks_base-user_build.patch"
         ;;
       *)

--- a/src/signature_spoofing_patches/android_frameworks_base-Android14.patch
+++ b/src/signature_spoofing_patches/android_frameworks_base-Android14.patch
@@ -1,0 +1,124 @@
+diff --git a/core/api/current.txt b/core/api/current.txt
+index 288ab479c0fb..2124d89c6e6f 100644
+--- a/core/api/current.txt
++++ b/core/api/current.txt
+@@ -95,6 +95,7 @@ package android {
+     field public static final String EXECUTE_APP_ACTION = "android.permission.EXECUTE_APP_ACTION";
+     field public static final String EXPAND_STATUS_BAR = "android.permission.EXPAND_STATUS_BAR";
+     field public static final String FACTORY_TEST = "android.permission.FACTORY_TEST";
++    field public static final String FAKE_PACKAGE_SIGNATURE = "android.permission.FAKE_PACKAGE_SIGNATURE";
+     field public static final String FOREGROUND_SERVICE = "android.permission.FOREGROUND_SERVICE";
+     field public static final String FOREGROUND_SERVICE_CAMERA = "android.permission.FOREGROUND_SERVICE_CAMERA";
+     field public static final String FOREGROUND_SERVICE_CONNECTED_DEVICE = "android.permission.FOREGROUND_SERVICE_CONNECTED_DEVICE";
+@@ -326,6 +327,7 @@ package android {
+     field public static final String CALL_LOG = "android.permission-group.CALL_LOG";
+     field public static final String CAMERA = "android.permission-group.CAMERA";
+     field public static final String CONTACTS = "android.permission-group.CONTACTS";
++    field public static final String FAKE_PACKAGE = "android.permission-group.FAKE_PACKAGE";
+     field public static final String LOCATION = "android.permission-group.LOCATION";
+     field public static final String MICROPHONE = "android.permission-group.MICROPHONE";
+     field public static final String NEARBY_DEVICES = "android.permission-group.NEARBY_DEVICES";
+diff --git a/core/res/AndroidManifest.xml b/core/res/AndroidManifest.xml
+index 14cb052b121f..593999bc4ef7 100644
+--- a/core/res/AndroidManifest.xml
++++ b/core/res/AndroidManifest.xml
+@@ -4258,6 +4258,22 @@
+         android:description="@string/permdesc_getPackageSize"
+         android:protectionLevel="normal" />
+ 
++    <!-- Dummy user-facing group for faking package signature -->
++    <permission-group android:name="android.permission-group.FAKE_PACKAGE"
++        android:label="@string/permgrouplab_fake_package_signature"
++        android:description="@string/permgroupdesc_fake_package_signature"
++        android:request="@string/permgrouprequest_fake_package_signature"
++        android:priority="100" />
++
++    <!-- Allows an application to change the package signature as
++         seen by applications -->
++    <permission android:name="android.permission.FAKE_PACKAGE_SIGNATURE"
++        android:permissionGroup="android.permission-group.UNDEFINED"
++        android:protectionLevel="dangerous"
++        android:label="@string/permlab_fakePackageSignature"
++        android:description="@string/permdesc_fakePackageSignature" />
++
++	
+     <!-- @deprecated No longer useful, see
+          {@link android.content.pm.PackageManager#addPackageToPreferred}
+          for details. -->
+diff --git a/core/res/res/values/strings.xml b/core/res/res/values/strings.xml
+index 9c018c30f9e3..661297bab701 100644
+--- a/core/res/res/values/strings.xml
++++ b/core/res/res/values/strings.xml
+@@ -990,6 +990,19 @@
+     <string name="dream_preview_title">Preview, <xliff:g id="dream_name" example="Clock">%1$s</xliff:g></string>
+ 
+     <!--  Permissions -->
++    
++    <!-- Title of an application permission, listed so the user can choose whether they want to allow the application to do this. -->
++    <string name="permlab_fakePackageSignature">Spoof package signature</string>
++    <!-- Description of an application permission, listed so the user can choose whether they want to allow the application to do this. -->
++    <string name="permdesc_fakePackageSignature">Allows the app to pretend to be a different app. Malicious applications might be able to use this to access private application data. Legitimate uses include an emulator pretending to be what it emulates. Grant this permission with caution only!</string>
++    <!-- Title of a category of application permissions, listed so the user can choose whether they want to allow the application to do this. -->
++    <string name="permgrouplab_fake_package_signature">Spoof package signature</string>
++    <!-- Description of a category of application permissions, listed so the user can choose whether they want to allow the application to do this. -->
++    <string name="permgroupdesc_fake_package_signature">allow to spoof package signature</string>
++    <!-- Message shown to the user when the apps requests permission from this group. If ever possible this should stay below 80 characters (assuming the parameters takes 20 characters). Don't abbreviate until the message reaches 120 characters though. [CHAR LIMIT=120] -->
++    <string name="permgrouprequest_fake_package_signature">Allow
++        &lt;b><xliff:g id="app_name" example="Gmail">%1$s</xliff:g>&lt;/b> to spoof package signature?</string>
++
+ 
+     <!-- Title of an application permission, listed so the user can choose whether they want to allow the application to do this. -->
+     <string name="permlab_statusBar">disable or modify status bar</string>
+diff --git a/services/core/java/com/android/server/pm/ComputerEngine.java b/services/core/java/com/android/server/pm/ComputerEngine.java
+index 78f1fa60b69f..1e29d3697b89 100644
+--- a/services/core/java/com/android/server/pm/ComputerEngine.java
++++ b/services/core/java/com/android/server/pm/ComputerEngine.java
+@@ -1450,6 +1450,29 @@ public class ComputerEngine implements Computer {
+         return result;
+     }
+ 
++        private boolean requestsFakeSignature(AndroidPackage p) {
++        return p.getMetaData() != null &&
++                p.getMetaData().getString("fake-signature") != null;
++    }
++
++    private PackageInfo mayFakeSignature(AndroidPackage p, PackageInfo pi,
++            Set<String> permissions) {
++        try {
++            if (p.getMetaData() != null &&
++                    p.getTargetSdkVersion() > Build.VERSION_CODES.LOLLIPOP_MR1) {
++                String sig = p.getMetaData().getString("fake-signature");
++                if (sig != null &&
++                        permissions.contains("android.permission.FAKE_PACKAGE_SIGNATURE")) {
++                    pi.signatures = new Signature[] {new Signature(sig)};
++                }
++            }
++        } catch (Throwable t) {
++            // We should never die because of any failures, this is system code!
++            Log.w("PackageManagerService.FAKE_PACKAGE_SIGNATURE", t);
++        }
++        return pi;
++    }
++
+     public final PackageInfo generatePackageInfo(PackageStateInternal ps,
+             @PackageManager.PackageInfoFlagsBits long flags, int userId) {
+         if (!mUserManager.exists(userId)) return null;
+@@ -1483,13 +1506,15 @@ public class ComputerEngine implements Computer {
+                     || ArrayUtils.isEmpty(p.getPermissions())) ? Collections.emptySet()
+                     : mPermissionManager.getInstalledPermissions(ps.getPackageName());
+             // Compute granted permissions only if package has requested permissions
+-            final Set<String> grantedPermissions = ((flags & PackageManager.GET_PERMISSIONS) == 0
++            final Set<String> grantedPermissions =  (((flags & PackageManager.GET_PERMISSIONS) == 0
++                        && !requestsFakeSignature(p))
+                     || ArrayUtils.isEmpty(p.getRequestedPermissions())) ? Collections.emptySet()
+                     : mPermissionManager.getGrantedPermissions(ps.getPackageName(), userId);
+ 
+-            PackageInfo packageInfo = PackageInfoUtils.generate(p, gids, flags,
++            PackageInfo packageInfo = mayFakeSignature(p, PackageInfoUtils.generate(p, gids, flags,
+                     state.getFirstInstallTimeMillis(), ps.getLastUpdateTime(), installedPermissions,
+-                    grantedPermissions, state, userId, ps);
++                    grantedPermissions, state, userId, ps),
++		    grantedPermissions);
+ 
+             if (packageInfo == null) {
+                 return null;

--- a/src/signature_spoofing_patches/packages_modules_Permission-Android14.patch
+++ b/src/signature_spoofing_patches/packages_modules_Permission-Android14.patch
@@ -1,0 +1,12 @@
+diff --git a/PermissionController/src/com/android/permissioncontroller/permission/utils/Utils.java b/PermissionController/src/com/android/permissioncontroller/permission/utils/Utils.java
+index d4354bd72..4b90f9327 100644
+--- a/PermissionController/src/com/android/permissioncontroller/permission/utils/Utils.java
++++ b/PermissionController/src/com/android/permissioncontroller/permission/utils/Utils.java
+@@ -21,6 +21,7 @@ import static android.Manifest.permission_group.CALENDAR;
+ import static android.Manifest.permission_group.CALL_LOG;
+ import static android.Manifest.permission_group.CAMERA;
+ import static android.Manifest.permission_group.CONTACTS;
++import static android.Manifest.permission_group.FAKE_PACKAGE;
+ import static android.Manifest.permission_group.LOCATION;
+ import static android.Manifest.permission_group.MICROPHONE;
+ import static android.Manifest.permission_group.NEARBY_DEVICES;


### PR DESCRIPTION
This restores the (still currently non-functional) Android 14 signature spoofing patches, so that, once they have been fixed, users will be able to create unrestricted patches.

These changes also mean that the error faced by @gwstorm is fixed.

If these are merged, the `nns-v21-spoofing-patches` branch no longer has any loss of functionality compared to master, and only improves compatibility. Therefore I believe that it should be able to be merged into master.

After (or before, but then there could be merge conflicts) that, we can focus on fixing the patches so that they work. I see you've already started work on that, thank you!