### PR TITLE
New fix a14 patches

### DIFF
--- a/src/build.sh
+++ b/src/build.sh
@@ -282,7 +282,9 @@ for branch in ${BRANCH_NAME//,/ }; do
     los_ver_minor=$(sed -n -e 's/^\s*PRODUCT_VERSION_MINOR = //p' "$makefile_containing_version")
     los_ver="$los_ver_major.$los_ver_minor"
 
+    patches_applied=false
     if [ "$APPLY_PATCHES" = true ]; then
+
       # If user build variant should also enable LOS signature spoofing
       if [ "$USER_BUILD_SPOOFING" = "yes" ]; then
         if [ -n "$user_build_spoofing_patch" ]; then
@@ -298,6 +300,7 @@ for branch in ${BRANCH_NAME//,/ }; do
 
       # If needed, apply the microG's signature spoofing patch
       if [ "$SIGNATURE_SPOOFING" = "yes" ] || [ "$SIGNATURE_SPOOFING" = "restricted" ]; then
+        patches_applied=true
         if [ -n "$frameworks_base_patch" ]; then
           echo ">> [$(date)] WARNING: Signature spoofing patches requested, but branch ($branch) does not support microG patches"
         else
@@ -467,6 +470,11 @@ for branch in ${BRANCH_NAME//,/ }; do
 
         build_successful=true
         if [ "$CALL_MKA" = true ]; then
+          if [ "$patches_applied" = true ]; then
+            # we changed the api - need to regenerate current.txt
+            m api-stubs-docs-non-updatable-update-current-api  &>> "$DEBUG_LOG"
+          fi
+
           # Start the build
           echo ">> [$(date)] Starting build for $codename, $branch branch" | tee -a "$DEBUG_LOG"
           build_successful=false

--- a/src/build.sh
+++ b/src/build.sh
@@ -285,8 +285,9 @@ for branch in ${BRANCH_NAME//,/ }; do
     patches_applied=false
     if [ "$APPLY_PATCHES" = true ]; then
 
-      # If user build variant should also enable LOS signature spoofing
       if [ "$USER_BUILD_SPOOFING" = "yes" ]; then
+        # For user builds, we need to patch the LOS signature spoofing code
+        # which were disabled for user builds
         if [ -n "$user_build_spoofing_patch" ]; then
           cd frameworks/base
           echo ">> [$(date)] Applying the user build variant signature spoofing patch ($user_build_spoofing_patch) to frameworks/base"

--- a/src/build.sh
+++ b/src/build.sh
@@ -302,7 +302,7 @@ for branch in ${BRANCH_NAME//,/ }; do
       # If needed, apply the microG's signature spoofing patch
       if [ "$SIGNATURE_SPOOFING" = "yes" ] || [ "$SIGNATURE_SPOOFING" = "restricted" ]; then
         patches_applied=true
-        if [ -n "$frameworks_base_patch" ]; then
+        if [ -z "$frameworks_base_patch" ]; then
           echo ">> [$(date)] WARNING: Signature spoofing patches requested, but branch ($branch) does not support microG patches"
         else
           # Determine which patch should be applied to the current Android source tree

--- a/src/signature_spoofing_patches/android_frameworks_base-Android14.patch
+++ b/src/signature_spoofing_patches/android_frameworks_base-Android14.patch
@@ -1,5 +1,5 @@
 diff --git a/core/api/current.txt b/core/api/current.txt
-index 288ab479c0fb..2124d89c6e6f 100644
+index 9b5316fb..1e7f6273 100644
 --- a/core/api/current.txt
 +++ b/core/api/current.txt
 @@ -95,6 +95,7 @@ package android {
@@ -10,7 +10,7 @@ index 288ab479c0fb..2124d89c6e6f 100644
      field public static final String FOREGROUND_SERVICE = "android.permission.FOREGROUND_SERVICE";
      field public static final String FOREGROUND_SERVICE_CAMERA = "android.permission.FOREGROUND_SERVICE_CAMERA";
      field public static final String FOREGROUND_SERVICE_CONNECTED_DEVICE = "android.permission.FOREGROUND_SERVICE_CONNECTED_DEVICE";
-@@ -326,6 +327,7 @@ package android {
+@@ -328,6 +329,7 @@ package android {
      field public static final String CALL_LOG = "android.permission-group.CALL_LOG";
      field public static final String CAMERA = "android.permission-group.CAMERA";
      field public static final String CONTACTS = "android.permission-group.CONTACTS";
@@ -18,15 +18,22 @@ index 288ab479c0fb..2124d89c6e6f 100644
      field public static final String LOCATION = "android.permission-group.LOCATION";
      field public static final String MICROPHONE = "android.permission-group.MICROPHONE";
      field public static final String NEARBY_DEVICES = "android.permission-group.NEARBY_DEVICES";
+@@ -61892,4 +61894,3 @@ package org.apache.http.params {
+   }
+ 
+ }
+-
 diff --git a/core/res/AndroidManifest.xml b/core/res/AndroidManifest.xml
-index 14cb052b121f..593999bc4ef7 100644
+index 22591641..cede3930 100644
 --- a/core/res/AndroidManifest.xml
 +++ b/core/res/AndroidManifest.xml
-@@ -4258,6 +4258,22 @@
+@@ -4318,6 +4318,26 @@
          android:description="@string/permdesc_getPackageSize"
          android:protectionLevel="normal" />
  
-+    <!-- Dummy user-facing group for faking package signature -->
++    <!-- Dummy user-facing group for faking package signature
++        @FlaggedApi("android.permission-group.FAKE_PACKAGE")
++    -->
 +    <permission-group android:name="android.permission-group.FAKE_PACKAGE"
 +        android:label="@string/permgrouplab_fake_package_signature"
 +        android:description="@string/permgroupdesc_fake_package_signature"
@@ -34,22 +41,24 @@ index 14cb052b121f..593999bc4ef7 100644
 +        android:priority="100" />
 +
 +    <!-- Allows an application to change the package signature as
-+         seen by applications -->
++         seen by applications
++        @FlaggedApi("android.permission-group.FAKE_PACKAGE_SIGNATURE")
++    -->
 +    <permission android:name="android.permission.FAKE_PACKAGE_SIGNATURE"
 +        android:permissionGroup="android.permission-group.UNDEFINED"
 +        android:protectionLevel="dangerous"
 +        android:label="@string/permlab_fakePackageSignature"
 +        android:description="@string/permdesc_fakePackageSignature" />
 +
-+	
++
      <!-- @deprecated No longer useful, see
           {@link android.content.pm.PackageManager#addPackageToPreferred}
           for details. -->
 diff --git a/core/res/res/values/strings.xml b/core/res/res/values/strings.xml
-index 9c018c30f9e3..661297bab701 100644
+index 4596ca74..a5ce5eb2 100644
 --- a/core/res/res/values/strings.xml
 +++ b/core/res/res/values/strings.xml
-@@ -990,6 +990,19 @@
+@@ -993,6 +993,19 @@
      <string name="dream_preview_title">Preview, <xliff:g id="dream_name" example="Clock">%1$s</xliff:g></string>
  
      <!--  Permissions -->
@@ -70,11 +79,11 @@ index 9c018c30f9e3..661297bab701 100644
      <!-- Title of an application permission, listed so the user can choose whether they want to allow the application to do this. -->
      <string name="permlab_statusBar">disable or modify status bar</string>
 diff --git a/services/core/java/com/android/server/pm/ComputerEngine.java b/services/core/java/com/android/server/pm/ComputerEngine.java
-index 78f1fa60b69f..1e29d3697b89 100644
+index d8cbe9d5..827a2061 100644
 --- a/services/core/java/com/android/server/pm/ComputerEngine.java
 +++ b/services/core/java/com/android/server/pm/ComputerEngine.java
-@@ -1450,6 +1450,29 @@ public class ComputerEngine implements Computer {
-         return result;
+@@ -1512,6 +1512,29 @@ public class ComputerEngine implements Computer {
+         return Optional.of(fakeSignature);
      }
  
 +        private boolean requestsFakeSignature(AndroidPackage p) {
@@ -103,7 +112,7 @@ index 78f1fa60b69f..1e29d3697b89 100644
      public final PackageInfo generatePackageInfo(PackageStateInternal ps,
              @PackageManager.PackageInfoFlagsBits long flags, int userId) {
          if (!mUserManager.exists(userId)) return null;
-@@ -1483,13 +1506,15 @@ public class ComputerEngine implements Computer {
+@@ -1545,13 +1568,15 @@ public class ComputerEngine implements Computer {
                      || ArrayUtils.isEmpty(p.getPermissions())) ? Collections.emptySet()
                      : mPermissionManager.getInstalledPermissions(ps.getPackageName());
              // Compute granted permissions only if package has requested permissions


### PR DESCRIPTION
Fix [Android 14 signature spoofing patch fails due to API changes #607](https://github.com/lineageos4microg/docker-lineage-cicd/issues/607)
- Add the `@FlaggedAPI` annotation in the patch for `AndroidManifest.xml`
- regenerate `current.txt` because we changed the API

Fix / improve some changes made in  `Nns v21 spoofing patches` #612
- Correct the logic controlling application of the patch (was broken in #612 )
- Improve the comment for applying the 'user' build patch 
