### PR TITLE
Pf fix 639 simplify key generation

### DIFF
--- a/src/init.sh
+++ b/src/init.sh
@@ -35,7 +35,7 @@ git config --global user.name "$USER_NAME"
 git config --global user.email "$USER_MAIL"
 
 if [ "$SIGN_BUILDS" = true ]; then
-  for c in bluetooth cyngn-app media networkstack nfc platform releasekey sdk_sandbox shared testcert testkey verity ; do
+  for c in bluetooth media networkstack nfc platform releasekey sdk_sandbox shared testcert verity ; do
     if [ ! -f "$KEYS_DIR/$c.pk8" ]; then
       echo ">> [$(date)]  Generating $c..."
       /root/make_key "$KEYS_DIR/$c" "$KEYS_SUBJECT" <<< '' &> /dev/null

--- a/src/init.sh
+++ b/src/init.sh
@@ -3,7 +3,7 @@
 # Docker init script
 # Copyright (c) 2017 Julian Xhokaxhiu
 # Copyright (C) 2017-2018 Nicola Corna <nicola@corna.info>
-# 
+#
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
@@ -34,32 +34,15 @@ fi
 git config --global user.name "$USER_NAME"
 git config --global user.email "$USER_MAIL"
 
-if [ "$SIGN_BUILDS" = true ]; then
-  if [ -z "$(ls -A "$KEYS_DIR")" ]; then
-    echo ">> [$(date)] SIGN_BUILDS = true but empty \$KEYS_DIR, generating new keys"
-    for c in releasekey platform shared media networkstack sdk_sandbox bluetooth; do
-      echo ">> [$(date)]  Generating $c..."
-      /root/make_key "$KEYS_DIR/$c" "$KEYS_SUBJECT" <<< '' &> /dev/null
-    done
-  else
-    for c in releasekey platform shared media networkstack; do
-      for e in pk8 x509.pem; do
-        if [ ! -f "$KEYS_DIR/$c.$e" ]; then
-          echo ">> [$(date)] SIGN_BUILDS = true and not empty \$KEYS_DIR, but \"\$KEYS_DIR/$c.$e\" is missing"
-          exit 1
-        fi
-      done
-    done
-    
-    # those keys are only required starting with android-20, so people who have built earlier might not yet have them
-    for c in sdk_sandbox bluetooth; do
+  if [ "$SIGN_BUILDS" = true ]; then
+    for c in releasekey platform shared media networkstack sdk_sandbox bluetooth ; do
       if [ ! -f "$KEYS_DIR/$c.pk8" ]; then
         echo ">> [$(date)]  Generating $c..."
         /root/make_key "$KEYS_DIR/$c" "$KEYS_SUBJECT" <<< '' &> /dev/null
       fi
     done
   fi
-  
+
   # Android 14 requires to set a BUILD file for bazel to avoid errors:
   cat > "$KEYS_DIR"/BUILD << _EOB
 # adding an empty BUILD file fixes the A14 build error:

--- a/src/init.sh
+++ b/src/init.sh
@@ -35,7 +35,7 @@ git config --global user.name "$USER_NAME"
 git config --global user.email "$USER_MAIL"
 
   if [ "$SIGN_BUILDS" = true ]; then
-    for c in releasekey platform shared media networkstack sdk_sandbox bluetooth ; do
+    for c in releasekey platform shared media networkstack nfc sdk_sandbox bluetooth ; do
       if [ ! -f "$KEYS_DIR/$c.pk8" ]; then
         echo ">> [$(date)]  Generating $c..."
         /root/make_key "$KEYS_DIR/$c" "$KEYS_SUBJECT" <<< '' &> /dev/null

--- a/src/init.sh
+++ b/src/init.sh
@@ -35,7 +35,7 @@ git config --global user.name "$USER_NAME"
 git config --global user.email "$USER_MAIL"
 
   if [ "$SIGN_BUILDS" = true ]; then
-    for c in releasekey platform shared media networkstack nfc sdk_sandbox bluetooth ; do
+    for c in bluetooth cyngn-app media networkstack nfc platform releasekey sdk_sandbox shared testcert testkey verity ; do
       if [ ! -f "$KEYS_DIR/$c.pk8" ]; then
         echo ">> [$(date)]  Generating $c..."
         /root/make_key "$KEYS_DIR/$c" "$KEYS_SUBJECT" <<< '' &> /dev/null


### PR DESCRIPTION
I've run this branch to fix the missing `nfc` error in `nx_tab` 21.0 build (see [this comment](https://github.com/lineageos4microg/docker-lineage-cicd/issues/636#issuecomment-2183805229)). We see the following in the log, as expected. so I thin we can merge this

```
Status: Downloaded newer image for lineageos4microg/docker-lineage-cicd:pf-fix-639-simplify-key-generation
>> [Sat Jun 22 15:30:32 UTC 2024]  Generating nfc...
>> [Sat Jun 22 15:30:33 UTC 2024]  Generating testcert...
>> [Sat Jun 22 15:30:33 UTC 2024]  Generating verity...
>> [Sat Jun 22 15:30:33 UTC 2024] Branch:  lineage-21.0
```