### PR TITLE
Fix some problems caused or ncovered by build restructure

### DIFF
--- a/src/new_build.sh
+++ b/src/new_build.sh
@@ -82,6 +82,7 @@ do_cleanup() {
       cd "$source_dir"
       (set +eu ; mka "${jobs_arg[@]}" clean) &>> "$DEBUG_LOG"
       rm -rf vendor/* || true
+      rm -rf kernel/* || true
     fi
   fi
 }

--- a/src/new_build.sh
+++ b/src/new_build.sh
@@ -160,7 +160,8 @@ fi
 branch_dir=${branch//[^[:alnum:]]/_}
 branch_dir=${branch_dir^^}
 
-mkdir -p "$SRC_DIR/$branch_dir"
+source_dir="$SRC_DIR/$branch_dir"
+mkdir -p "$source_dir"
 cd "$SRC_DIR/$branch_dir"
 
 if [ -n "$branch" ] && [ -n "$devices" ]; then

--- a/src/new_build.sh
+++ b/src/new_build.sh
@@ -82,12 +82,14 @@ do_cleanup() {
     else
       cd "$source_dir"
       (set +eu ; mka "${jobs_arg[@]}" clean) &>> "$DEBUG_LOG"
-      echo ">> [$(date)] Removing $PWD/vendor for device $codename" | tee -a "$DEBUG_LOG"
-      rm -rf vendor/* || true
-      echo ">> [$(date)] Removing $PWD/kernel for device $codename" | tee -a "$DEBUG_LOG"
-      rm -rf kernel/* || true
-      echo ">> [$(date)] Removing $PWD/device for device $codename" | tee -a "$DEBUG_LOG"
-      rm -rf device/* || true
+      # echo ">> [$(date)] Removing $PWD/vendor" | tee -a "$DEBUG_LOG"
+      # rm -rf vendor/* || true
+      # echo ">> [$(date)] Removing $PWD/kernel" | tee -a "$DEBUG_LOG"
+      # rm -rf kernel/* || true
+      # echo ">> [$(date)] Removing $PWD/device" | tee -a "$DEBUG_LOG"
+      # rm -rf device/* || true
+      echo ">> [$(date)] Removing $PWD/.repo/local_manifests/roomservice.xml" | tee -a "$DEBUG_LOG"
+      rm -f .repo/local_manifests/roomservice.xml
     fi
   fi
 }
@@ -183,7 +185,7 @@ if [ -n "$branch" ] && [ -n "$devices" ]; then
     android_version_major=$(cut -d '.' -f 1 <<< $android_version)
 fi
 
-# Handle local manifests
+# Handle local ts
 ## Copy local manifests
 echo ">> [$(date)] Copying '$LMANIFEST_DIR/*.xml' to '.repo/local_manifests/'"
 mkdir -p .repo/local_manifests

--- a/src/new_build.sh
+++ b/src/new_build.sh
@@ -82,8 +82,8 @@ do_cleanup() {
     else
       cd "$source_dir"
       (set +eu ; mka "${jobs_arg[@]}" clean) &>> "$DEBUG_LOG"
-      # echo ">> [$(date)] Removing $PWD/vendor" | tee -a "$DEBUG_LOG"
-      # rm -rf vendor/* || true
+      echo ">> [$(date)] Removing $PWD/vendor" | tee -a "$DEBUG_LOG"
+      rm -rf vendor/* || true
       # echo ">> [$(date)] Removing $PWD/kernel" | tee -a "$DEBUG_LOG"
       # rm -rf kernel/* || true
       # echo ">> [$(date)] Removing $PWD/device" | tee -a "$DEBUG_LOG"

--- a/src/new_build.sh
+++ b/src/new_build.sh
@@ -76,13 +76,17 @@ do_cleanup() {
   if [ "$CLEAN_AFTER_BUILD" = true ]; then
     echo ">> [$(date)] Cleaning source dir for device $codename" | tee -a "$DEBUG_LOG"
     if [ "$BUILD_OVERLAY" = true ]; then
+      echo ">> [$(date)] Removing $TMP_DIR for device $codename" | tee -a "$DEBUG_LOG"
       cd "$TMP_DIR"
       rm -rf ./* || true
     else
       cd "$source_dir"
       (set +eu ; mka "${jobs_arg[@]}" clean) &>> "$DEBUG_LOG"
+      echo ">> [$(date)] Removing $PWD/vendor for device $codename" | tee -a "$DEBUG_LOG"
       rm -rf vendor/* || true
+      echo ">> [$(date)] Removing $PWD/kernel for device $codename" | tee -a "$DEBUG_LOG"
       rm -rf kernel/* || true
+      echo ">> [$(date)] Removing $PWD/device for device $codename" | tee -a "$DEBUG_LOG"
       rm -rf device/* || true
     fi
   fi

--- a/src/new_build.sh
+++ b/src/new_build.sh
@@ -83,6 +83,7 @@ do_cleanup() {
       (set +eu ; mka "${jobs_arg[@]}" clean) &>> "$DEBUG_LOG"
       rm -rf vendor/* || true
       rm -rf kernel/* || true
+      rm -rf device/* || true
     fi
   fi
 }

--- a/src/new_build.sh
+++ b/src/new_build.sh
@@ -192,14 +192,6 @@ echo ">> [$(date)] Copying '$LMANIFEST_DIR/*.xml' to '.repo/local_manifests/'"
 mkdir -p .repo/local_manifests
 rsync -a --delete --include '*.xml' --exclude '*' "$LMANIFEST_DIR/" .repo/local_manifests/
 
-## Pick up TheMuppets manifest if required
-rm -f .repo/local_manifests/proprietary.xml
-if [ "$INCLUDE_PROPRIETARY" = true ]; then
-  wget -q -O .repo/local_manifests/proprietary.xml "https://raw.githubusercontent.com/TheMuppets/manifests/$themuppets_branch/muppets.xml"
-  /root/build_manifest.py --remote "https://gitlab.com" --remotename "gitlab_https" \
-    "https://gitlab.com/the-muppets/manifest/raw/$themuppets_branch/muppets.xml" .repo/local_manifests/proprietary_gitlab.xml
-fi
-
 # Sync mirror if we're using one
 if [ "$LOCAL_MIRROR" = true ]; then
   echo "Using LOCAL_MIRROR is not yet working"
@@ -244,7 +236,14 @@ for codename in ${devices//,/ }; do
     fi
 
     # Set device specific logfils
-   DEBUG_LOG="$LOGS_DIR/$logsubdir/$branch-$builddate-$RELEASE_TYPE-$codename.log"
+    DEBUG_LOG="$LOGS_DIR/$logsubdir/$branch-$builddate-$RELEASE_TYPE-$codename.log"
+    ## Pick up TheMuppets manifest if required
+    rm -f .repo/local_manifests/proprietary.xml
+    if [ "$INCLUDE_PROPRIETARY" = true ]; then
+      wget -q -O .repo/local_manifests/proprietary.xml "https://raw.githubusercontent.com/TheMuppets/manifests/$themuppets_branch/muppets.xml"
+      /root/build_manifest.py --remote "https://gitlab.com" --remotename "gitlab_https" \
+        "https://gitlab.com/the-muppets/manifest/raw/$themuppets_branch/muppets.xml" .repo/local_manifests/proprietary_gitlab.xml
+    fi
 
   # `repo init`
   if [ "$CALL_REPO_INIT" = true ]; then

--- a/src/new_build.sh
+++ b/src/new_build.sh
@@ -84,10 +84,6 @@ do_cleanup() {
       (set +eu ; mka "${jobs_arg[@]}" clean) &>> "$DEBUG_LOG"
       echo ">> [$(date)] Removing $PWD/vendor" | tee -a "$DEBUG_LOG"
       rm -rf vendor/* || true
-      # echo ">> [$(date)] Removing $PWD/kernel" | tee -a "$DEBUG_LOG"
-      # rm -rf kernel/* || true
-      # echo ">> [$(date)] Removing $PWD/device" | tee -a "$DEBUG_LOG"
-      # rm -rf device/* || true
       echo ">> [$(date)] Removing $PWD/.repo/local_manifests/roomservice.xml" | tee -a "$DEBUG_LOG"
       rm -f .repo/local_manifests/roomservice.xml
     fi

--- a/src/new_build.sh
+++ b/src/new_build.sh
@@ -241,54 +241,19 @@ for codename in ${devices//,/ }; do
         "https://gitlab.com/the-muppets/manifest/raw/$themuppets_branch/muppets.xml" .repo/local_manifests/proprietary_gitlab.xml
     fi
 
-  # `repo init`
-  if [ "$CALL_REPO_INIT" = true ]; then
-    echo ">> [$(date)] (Re)initializing branch repository" | tee -a "$repo_log"
-    if [ "$LOCAL_MIRROR" = true ]; then
-      ( yes||: ) | repo init -u https://github.com/LineageOS/android.git --reference "$MIRROR_DIR" -b "$branch" -g default,-darwin,-muppets,muppets_"${codename}" --git-lfs &>> "$repo_log"
-    else
-      ( yes||: ) | repo init -u https://github.com/LineageOS/android.git -b "$branch" -g default,-darwin,-muppets,muppets_"${codename}" --git-lfs &>> "$repo_log"
-    fi
-  else
-    echo ">> [$(date)] Calling repo init disabled"
-  fi
-
-  # `repo sync`
-  repo_sync_returncode=0
-  if [ "$CALL_REPO_SYNC" = true ]; then
-    set +eu
-    echo ">> [$(date)] Syncing branch repository" | tee -a "$repo_log"
-    repo sync "${jobs_arg[@]}" "${retry_fetches_arg[@]}" --current-branch --force-sync &>> "$repo_log"
-    repo_sync_returncode=$?
-    set -eu
-  else
-    echo ">> [$(date)] Syncing branch repository disabled" | tee -a "$repo_log"
-  fi
-
-  if [ $repo_sync_returncode -ne 0 ]; then
-      echo ">> [$(date)] repo sync failed for $codename, $branch branch" | tee -a "$DEBUG_LOG"
-      # call post-build.sh so the failure is logged in a way that is more visible
-      if [ -f /root/userscripts/post-build.sh ]; then
-        echo ">> [$(date)] Running post-build.sh for $codename" >> "$DEBUG_LOG"
-        /root/userscripts/post-build.sh "$codename" false "$branch" &>> "$DEBUG_LOG" || echo ">> [$(date)] Warning: post-build.sh failed!"
+    # `repo init`
+    if [ "$CALL_REPO_INIT" = true ]; then
+      echo ">> [$(date)] (Re)initializing branch repository" | tee -a "$repo_log"
+      if [ "$LOCAL_MIRROR" = true ]; then
+        ( yes||: ) | repo init -u https://github.com/LineageOS/android.git --reference "$MIRROR_DIR" -b "$branch" -g default,-darwin,-muppets,muppets_"${codename}" --git-lfs &>> "$repo_log"
+      else
+        ( yes||: ) | repo init -u https://github.com/LineageOS/android.git -b "$branch" -g default,-darwin,-muppets,muppets_"${codename}" --git-lfs &>> "$repo_log"
       fi
-      do_cleanup
-      continue
-  fi
+    else
+      echo ">> [$(date)] Calling repo init disabled"
+    fi
 
-  if [ "$CALL_GIT_LFS_PULL" = true ]; then
-    echo ">> [$(date)] Calling git lfs pull" | tee -a "$repo_log"
-    repo forall -v -c git lfs pull &>> "$repo_log"
-  else
-    echo ">> [$(date)] Calling git lfs pull disabled" | tee -a "$repo_log"
-  fi
-
-  if [ ! -d "vendor/$vendor" ]; then
-    echo ">> [$(date)] Missing \"vendor/$vendor\", aborting"
-    exit 1
-  fi
-
-  # Setup our overlays
+    # Setup our overlays
     if [ "$BUILD_OVERLAY" = true ]; then
       echo "Using BUILD_OVERLAY is not yet working"
       exit 1
@@ -314,8 +279,6 @@ for codename in ${devices//,/ }; do
     los_ver_major=$(sed -n -e 's/^\s*PRODUCT_VERSION_MAJOR = //p' "$makefile_containing_version")
     los_ver_minor=$(sed -n -e 's/^\s*PRODUCT_VERSION_MINOR = //p' "$makefile_containing_version")
     los_ver="$los_ver_major.$los_ver_minor"
-
-#    DEBUG_LOG="$LOGS_DIR/$logsubdir/lineage-$los_ver-$builddate-$RELEASE_TYPE-$codename.log"
 
     # Set RELEASE_TYPE
     echo ">> [$(date)] Setting \"$RELEASE_TYPE\" as release type"

--- a/src/new_build.sh
+++ b/src/new_build.sh
@@ -234,6 +234,9 @@ for codename in ${devices//,/ }; do
       logsubdir=
     fi
 
+    # Set device specific logfils
+   DEBUG_LOG="$LOGS_DIR/$logsubdir/$branch-$builddate-$RELEASE_TYPE-$codename.log"
+
   # `repo init`
   if [ "$CALL_REPO_INIT" = true ]; then
     echo ">> [$(date)] (Re)initializing branch repository" | tee -a "$repo_log"
@@ -308,7 +311,7 @@ for codename in ${devices//,/ }; do
     los_ver_minor=$(sed -n -e 's/^\s*PRODUCT_VERSION_MINOR = //p' "$makefile_containing_version")
     los_ver="$los_ver_major.$los_ver_minor"
 
-    DEBUG_LOG="$LOGS_DIR/$logsubdir/lineage-$los_ver-$builddate-$RELEASE_TYPE-$codename.log"
+#    DEBUG_LOG="$LOGS_DIR/$logsubdir/lineage-$los_ver-$builddate-$RELEASE_TYPE-$codename.log"
 
     # Set RELEASE_TYPE
     echo ">> [$(date)] Setting \"$RELEASE_TYPE\" as release type"


### PR DESCRIPTION
A number of build failures have occurred because of problems introduced by the new build structure & related changes
- `DEBUG_LOG` not initialised before use - see #694: 
    - fix is to set `DEBUG_LOG` as soon as we know `codename`
- the `do_cleanup` code doesn't do enough when we're not using  `BUILD_OVERLAY` - it calls `mka clean` which will remove `./out`, but it leaves the source directories create during the call to `breakfast`. This can leave a mess, particularly in the `,/device`, `,/kernel` and `,/vendor` source directories - see #696 & #688 
    - fix is to `rm -rf` those directory trees also. They will get repopulated when we call `repo sync` for the next device

merging these fixes should also fix #693 