### PR TITLE
accomodating v6* branches

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ ENV CCACHE_EXEC /usr/bin/ccache
 
 # Environment for the IodeOS branches name
 # https://gitlab.iode.tech/os/public/manifests/android/-/branches for possible options
-ENV BRANCH_NAME 'v5-staging'
+ENV BRANCH_NAME 'v6-staging'
 
 # Environment for the device list (separate by comma if more than one)
 # eg. DEVICE_LIST=hammerhead,bullhead,angler

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ ENV CCACHE_EXEC /usr/bin/ccache
 
 # Environment for the IodeOS branches name
 # https://gitlab.iode.tech/os/public/manifests/android/-/branches for possible options
-ENV BRANCH_NAME 'v6-staging'
+ENV BRANCH_NAME 'v5-staging'
 
 # Environment for the device list (separate by comma if more than one)
 # eg. DEVICE_LIST=hammerhead,bullhead,angler

--- a/src/new_build.sh
+++ b/src/new_build.sh
@@ -187,7 +187,7 @@ if [ -n "$branch" ] && [ -n "$devices" ]; then
       themuppets_branch="lineage-21.0"
       android_version="14"
       ;;
-    lineage-22.1*)
+    lineage-22.1* | v6*)
       themuppets_branch="lineage-22.1"
       android_version="15"
       ;;


### PR DESCRIPTION
Very minor changes here, but I have a couple questions:

1. Would we keep different branches for each iodé version? So "pf-build-iodeOS-v5" and "pf-build-iodeOS-v6"? As `new_build.sh` can accomodate all versions, I think a single branch is OK. But what about the change to the `Dockerfile` indicating that `v6-staging` is now the tracking branch instead of `v5-staging`? With that set to `v6` is it still possible to make `v5` builds?
2. Curious if we need to add a signature spoofing patch for Android 22.1? Or maybe as I understand now, custom spoofing patches are NOT needed since we build `userdebug` builds, and upstream LOS handles that.
3. I may have messed up in making a new PR for this so it is now #741 instead of being linked to #740. I'll need to sort out how to tie a PR to an existing issues in the future.
4. I am not sure how to test locally, basically I would need to learn how to generate a new Docker image, correct? Hmm more learning ahead..
5. I noticed the `pf-build-iodeOS` branch is a few commits behind `master` do we need to apply any of those commits here?