### PR TITLE
get rid of the case statements because it needs maintenance

### DIFF
--- a/src/init.sh
+++ b/src/init.sh
@@ -65,14 +65,21 @@ visibility = ["//visibility:public"],
 )
 _EOB
 
-case "$BRANCH_NAME" in
-  "lineage-19.1" | "lineage-20.0" | "lineage-21.0" | "lineage-22.1" )
-    build_file="new_build.sh"
-    ;;
-  * )
-    build_file="legacy-build.sh"
-    ;;
-esac
+BRANCH_NUM = ${BRANCH_NAME##*-}
+if (( $(echo "$BRANCH_NUM < 19.1" |bc -l) )); then
+  build_file="legacy-build.sh"
+else
+  build_file="new_build.sh"
+fi
+
+#case "$BRANCH_NAME" in
+#  "lineage-19.1" | "lineage-20.0" | "lineage-21.0" | "lineage-22.1" )
+#    build_file="new_build.sh"
+#    ;;
+#  * )
+#    build_file="legacy-build.sh"
+#    ;;
+#esac
 
 if [ "$CRONTAB_TIME" = "now" ]; then
   /root/$build_file

--- a/src/init.sh
+++ b/src/init.sh
@@ -65,21 +65,13 @@ visibility = ["//visibility:public"],
 )
 _EOB
 
+# select legacy or new build script
 BRANCH_NUM=${BRANCH_NAME##*-}
 if (( $(echo "$BRANCH_NUM < 19.1" |bc -l) )); then
   build_file="legacy-build.sh"
 else
   build_file="new_build.sh"
 fi
-
-#case "$BRANCH_NAME" in
-#  "lineage-19.1" | "lineage-20.0" | "lineage-21.0" | "lineage-22.1" )
-#    build_file="new_build.sh"
-#    ;;
-#  * )
-#    build_file="legacy-build.sh"
-#    ;;
-#esac
 
 if [ "$CRONTAB_TIME" = "now" ]; then
   /root/$build_file

--- a/src/init.sh
+++ b/src/init.sh
@@ -65,7 +65,7 @@ visibility = ["//visibility:public"],
 )
 _EOB
 
-BRANCH_NUM = ${BRANCH_NAME##*-}
+BRANCH_NUM=${BRANCH_NAME##*-}
 if (( $(echo "$BRANCH_NUM < 19.1" |bc -l) )); then
   build_file="legacy-build.sh"
 else

--- a/src/init.sh
+++ b/src/init.sh
@@ -66,8 +66,7 @@ visibility = ["//visibility:public"],
 _EOB
 
 # select legacy or new build script
-BRANCH_NUM=${BRANCH_NAME##*-}
-if (( $(echo "$BRANCH_NUM < 19.1" |bc -l) )); then
+if (( $(echo "${BRANCH_NAME##*-} < 19.1" |bc -l) )); then
   build_file="legacy-build.sh"
 else
   build_file="new_build.sh"

--- a/src/new_build.sh
+++ b/src/new_build.sh
@@ -173,6 +173,22 @@ if [ -n "$branch" ] && [ -n "$devices" ]; then
       themuppets_branch="lineage-22.1"
       android_version="15"
       ;;
+    lineage-22.2*)
+      themuppets_branch="lineage-22.2"
+      android_version="15"
+      ;;
+    lineage-23.0*)
+      themuppets_branch="lineage-23.0"
+      android_version="16"
+      ;;
+    lineage-23.1*)
+      themuppets_branch="lineage-23.1"
+      android_version="16"
+      ;;
+    lineage-23.2*)
+      themuppets_branch="lineage-23.2"
+      android_version="16"
+      ;;
     *)
       echo ">> [$(date)] Building branch $branch is not (yet) suppported"
       exit 1

--- a/src/new_build.sh
+++ b/src/new_build.sh
@@ -156,7 +156,7 @@ mkdir -p "$source_dir"
 cd "$SRC_DIR/$branch_dir"
 
 # select branch and android version without maintaining a list
-branch_num = ${branch##*-}
+branch_num=${branch##*-}
 themuppets_branch=$branch
 android_version=$(echo "($branch_num - 7) / 1" | bc)
 android_version_major=$(cut -d '.' -f 1 <<< $android_version)

--- a/src/new_build.sh
+++ b/src/new_build.sh
@@ -158,8 +158,9 @@ cd "$SRC_DIR/$branch_dir"
 # select branch and android version without maintaining a list
 branch_num=${branch##*-}
 themuppets_branch=$branch
+# This will strip off the minor version as well. Remove the '/ 1' part to get a version like 12.1
 android_version=$(echo "($branch_num - 7) / 1" | bc)
-android_version_major=$(cut -d '.' -f 1 <<< $android_version)
+android_version_major=$(echo "($branch_num - 7) / 1" | bc)
 
 if [ "$RESET_VENDOR_UNDO_PATCHES" = true ]; then
   # Remove previous changes of vendor/cm, vendor/lineage and frameworks/base (if they exist)

--- a/src/new_build.sh
+++ b/src/new_build.sh
@@ -161,49 +161,6 @@ themuppets_branch=$branch
 android_version=$(echo "($branch_num - 7) / 1" | bc)
 android_version_major=$(cut -d '.' -f 1 <<< $android_version)
 
-# old behaviour
-#if [ -n "$branch" ] && [ -n "$devices" ]; then
-#  case "$branch" in
-#    lineage-19.1*)
-#      themuppets_branch="lineage-19.1"
-#      android_version="12"
-#      ;;
-#    lineage-20.0*)
-#      themuppets_branch="lineage-20.0"
-#      android_version="13"
-#      ;;
-#    lineage-21.0*)
-#      themuppets_branch="lineage-21.0"
-#      android_version="14"
-#      ;;
-#    lineage-22.1*)
-#      themuppets_branch="lineage-22.1"
-#      android_version="15"
-#      ;;
-#    lineage-22.2*)
-#      themuppets_branch="lineage-22.2"
-#      android_version="15"
-#      ;;
-#    lineage-23.0*)
-#      themuppets_branch="lineage-23.0"
-#      android_version="16"
-#      ;;
-#    lineage-23.1*)
-#      themuppets_branch="lineage-23.1"
-#      android_version="16"
-#      ;;
-#    lineage-23.2*)
-#      themuppets_branch="lineage-23.2"
-#      android_version="16"
-#      ;;
-#    *)
-#      echo ">> [$(date)] Building branch $branch is not (yet) suppported"
-#      exit 1
-#      ;;
-#    esac
-#    android_version_major=$(cut -d '.' -f 1 <<< $android_version)
-#fi
-
 if [ "$RESET_VENDOR_UNDO_PATCHES" = true ]; then
   # Remove previous changes of vendor/cm, vendor/lineage and frameworks/base (if they exist)
   # TODO: maybe reset everything using https://source.android.com/setup/develop/repo#forall

--- a/src/new_build.sh
+++ b/src/new_build.sh
@@ -155,47 +155,54 @@ source_dir="$SRC_DIR/$branch_dir"
 mkdir -p "$source_dir"
 cd "$SRC_DIR/$branch_dir"
 
-if [ -n "$branch" ] && [ -n "$devices" ]; then
-  case "$branch" in
-    lineage-19.1*)
-      themuppets_branch="lineage-19.1"
-      android_version="12"
-      ;;
-    lineage-20.0*)
-      themuppets_branch="lineage-20.0"
-      android_version="13"
-      ;;
-    lineage-21.0*)
-      themuppets_branch="lineage-21.0"
-      android_version="14"
-      ;;
-    lineage-22.1*)
-      themuppets_branch="lineage-22.1"
-      android_version="15"
-      ;;
-    lineage-22.2*)
-      themuppets_branch="lineage-22.2"
-      android_version="15"
-      ;;
-    lineage-23.0*)
-      themuppets_branch="lineage-23.0"
-      android_version="16"
-      ;;
-    lineage-23.1*)
-      themuppets_branch="lineage-23.1"
-      android_version="16"
-      ;;
-    lineage-23.2*)
-      themuppets_branch="lineage-23.2"
-      android_version="16"
-      ;;
-    *)
-      echo ">> [$(date)] Building branch $branch is not (yet) suppported"
-      exit 1
-      ;;
-    esac
-    android_version_major=$(cut -d '.' -f 1 <<< $android_version)
-fi
+# select branch and android version without maintaining a list
+branch_num = ${branch##*-}
+themuppets_branch=$branch
+android_version=$(echo "($branch_num - 7) / 1" | bc)
+android_version_major=$(cut -d '.' -f 1 <<< $android_version)
+
+# old behaviour
+#if [ -n "$branch" ] && [ -n "$devices" ]; then
+#  case "$branch" in
+#    lineage-19.1*)
+#      themuppets_branch="lineage-19.1"
+#      android_version="12"
+#      ;;
+#    lineage-20.0*)
+#      themuppets_branch="lineage-20.0"
+#      android_version="13"
+#      ;;
+#    lineage-21.0*)
+#      themuppets_branch="lineage-21.0"
+#      android_version="14"
+#      ;;
+#    lineage-22.1*)
+#      themuppets_branch="lineage-22.1"
+#      android_version="15"
+#      ;;
+#    lineage-22.2*)
+#      themuppets_branch="lineage-22.2"
+#      android_version="15"
+#      ;;
+#    lineage-23.0*)
+#      themuppets_branch="lineage-23.0"
+#      android_version="16"
+#      ;;
+#    lineage-23.1*)
+#      themuppets_branch="lineage-23.1"
+#      android_version="16"
+#      ;;
+#    lineage-23.2*)
+#      themuppets_branch="lineage-23.2"
+#      android_version="16"
+#      ;;
+#    *)
+#      echo ">> [$(date)] Building branch $branch is not (yet) suppported"
+#      exit 1
+#      ;;
+#    esac
+#    android_version_major=$(cut -d '.' -f 1 <<< $android_version)
+#fi
 
 if [ "$RESET_VENDOR_UNDO_PATCHES" = true ]; then
   # Remove previous changes of vendor/cm, vendor/lineage and frameworks/base (if they exist)


### PR DESCRIPTION
In order to get rid of the long list of "supported" lineage branches I propose a solution that does not need any more maintenance at each lineage version as long as the offset between lineage version and android version remains 7.
Background is, that I often could not build the newest lineage development version because of the lineage version in the case statements was outdated.