### PR TITLE
Code changes tosupport 22.2 and future branches

### DIFF
--- a/src/init.sh
+++ b/src/init.sh
@@ -65,14 +65,12 @@ visibility = ["//visibility:public"],
 )
 _EOB
 
-case "$BRANCH_NAME" in
-  "lineage-19.1" | "lineage-20.0" | "lineage-21.0" | "lineage-22.1" )
-    build_file="new_build.sh"
-    ;;
-  * )
-    build_file="legacy-build.sh"
-    ;;
-esac
+# select legacy or new build script
+if (( $(echo "${BRANCH_NAME##*-} < 19.1" |bc -l) )); then
+  build_file="legacy-build.sh"
+else
+  build_file="new_build.sh"
+fi
 
 if [ "$CRONTAB_TIME" = "now" ]; then
   /root/$build_file

--- a/src/new_build.sh
+++ b/src/new_build.sh
@@ -158,8 +158,8 @@ cd "$SRC_DIR/$branch_dir"
 # select branch and android version without maintaining a list
 branch_num=${branch##*-}
 themuppets_branch=$branch
-# This will strip off the minor version as well. Remove the '/ 1' part to get a version like 12.1
-android_version=$(echo "($branch_num - 7) / 1" | bc)
+android_version=$(echo "($branch_num - 7)" | bc)
+echo ">> [$(date)] Android version: $android_version"
 android_version_major=$(echo "($branch_num - 7) / 1" | bc)
 
 if [ "$RESET_VENDOR_UNDO_PATCHES" = true ]; then

--- a/src/new_build.sh
+++ b/src/new_build.sh
@@ -155,31 +155,12 @@ source_dir="$SRC_DIR/$branch_dir"
 mkdir -p "$source_dir"
 cd "$SRC_DIR/$branch_dir"
 
-if [ -n "$branch" ] && [ -n "$devices" ]; then
-  case "$branch" in
-    lineage-19.1*)
-      themuppets_branch="lineage-19.1"
-      android_version="12"
-      ;;
-    lineage-20.0*)
-      themuppets_branch="lineage-20.0"
-      android_version="13"
-      ;;
-    lineage-21.0*)
-      themuppets_branch="lineage-21.0"
-      android_version="14"
-      ;;
-    lineage-22.1*)
-      themuppets_branch="lineage-22.1"
-      android_version="15"
-      ;;
-    *)
-      echo ">> [$(date)] Building branch $branch is not (yet) suppported"
-      exit 1
-      ;;
-    esac
-    android_version_major=$(cut -d '.' -f 1 <<< $android_version)
-fi
+# select branch and android version without maintaining a list
+branch_num=${branch##*-}
+themuppets_branch=$branch
+# This will strip off the minor version as well. Remove the '/ 1' part to get a version like 12.1
+android_version=$(echo "($branch_num - 7) / 1" | bc)
+android_version_major=$(echo "($branch_num - 7) / 1" | bc)
 
 if [ "$RESET_VENDOR_UNDO_PATCHES" = true ]; then
   # Remove previous changes of vendor/cm, vendor/lineage and frameworks/base (if they exist)


### PR DESCRIPTION
Fixes Get ready for 22.2 builds #751

Uses the code submitted by @strayedelectron  in #755

Should be 'future-proof', and able to handle new branches without modification

Tested as described in https://github.com/lineageos4microg/docker-lineage-cicd/issues/751#issuecomment-2802989952

We no longer check `BRANCH_NAME` and exit with an error if it is unrecognised / unsupported, allowing users more flexibility to build branches not supported by us. 

@rik-shaw Please will you give this PR a quick review before I merge it?
