### PR TITLE
Rik iode branch fix

### DIFF
--- a/src/new_build.sh
+++ b/src/new_build.sh
@@ -159,6 +159,7 @@ case "$PRODUCT" in
         exit 1
         ;;
     esac
+    ;;
 
   *)
     echo ">> [$(date)] Building product $PRODUCT is not (yet) suppported"

--- a/src/new_build.sh
+++ b/src/new_build.sh
@@ -139,19 +139,19 @@ case "$PRODUCT" in
 
     case "$branch" in
       v3*)
-        themuppets_branch="lineage19.1"
+        themuppets_branch="lineage-19.1"
         android_version=12
         ;;
       v4*)
-        themuppets_branch="lineage20.0"
+        themuppets_branch="lineage-20.0"
         android_version=13
         ;;
       v5*)
-        themuppets_branch="lineage21.0"
+        themuppets_branch="lineage-21.0"
         android_version=14
         ;;
       v6*)
-        themuppets_branch="lineage22.1"
+        themuppets_branch="lineage-22.1"
         android_version=15
         ;;
       *)

--- a/src/new_build.sh
+++ b/src/new_build.sh
@@ -138,21 +138,21 @@ case "$PRODUCT" in
     #   android_version_major=$(echo "($branch_num + 9) / 1" | bc)
 
     case "$branch" in
-      v6*)
-        themuppets_branch="lineage22.1"
-        android_version=15
-        ;;
-      v5*)
-        themuppets_branch="lineage21.0"
-        android_version=14
+      v3*)
+        themuppets_branch="lineage19.1"
+        android_version=12
         ;;
       v4*)
         themuppets_branch="lineage20.0"
         android_version=13
         ;;
-      v3*)
-        themuppets_branch="lineage19.1"
-        android_version=12
+      v5*)
+        themuppets_branch="lineage21.0"
+        android_version=14
+        ;;
+      v6*)
+        themuppets_branch="lineage22.1"
+        android_version=15
         ;;
       *)
         echo ">> [$(date)] Building iodeOS branch $branch is not (yet) suppported"
@@ -160,7 +160,6 @@ case "$PRODUCT" in
         ;;
     esac
     ;;
-
   *)
     echo ">> [$(date)] Building product $PRODUCT is not (yet) suppported"
     exit 1


### PR DESCRIPTION
@petefoth this PR addresses the regression referenced in #762 to re-add hard-coded logic for determining the `android version` and `themuppets_branch` for iodéOS builds. The programmatic determination of android version for `l4m` builds is retained, but was moved up to the product specific variable section. 