### PR TITLE
Don't apply PI-patch for gta4l & gta4lwifi devices

### DIFF
--- a/src/new_build.sh
+++ b/src/new_build.sh
@@ -420,7 +420,8 @@ for codename in ${devices//,/ }; do
     fi
 
     # Apply the PlayIntegrity patch if the APPLY_PI_PATCH is set
-    if [ "$APPLY_PI_PATCH" = true ]; then
+    # but not for `gta4l` & gta4lwifi
+    if [ "$APPLY_PI_PATCH" = true ] && [ "$codename" != gta4l ] && [ "$codename" != gta4lwifi ]; then
       echo ">> [$(date)] Applying the PlayIntegrity patch for $codename" >> "$DEBUG_LOG"
       cd system/core
 
@@ -431,7 +432,7 @@ for codename in ${devices//,/ }; do
         echo ">> [$(date)] Error: Applying the PlayIntegrity patch failed for $codename on $branch!"; userscriptfail=true; continue; }
       cd ../..
     else
-      echo ">> [$(date)] Applying PlayIntegrity patch disabled" | tee -a "$repo_log"
+      echo ">> [$(date)] Applying PlayIntegrity patch disabled"  >> "$DEBUG_LOG"
     fi
 
     # Call pre-build.sh


### PR DESCRIPTION
Should fix #819

Testing:
- Make builds of `gta4lwifi,gta4lwifi,gta4xl` with `APPLY_PI_PATCH=true`
- Check that 
    - all three builds succeed 
    - logs for `gta4lwifi,gta4lwifi` states "Applying PlayIntegrity patch disabled" 
    -  logs for `gta4xl` states "Applying the PlayIntegrity patch forgta4xl "