### PR TITLE
Fix BT signing keys in 23.2 builds

### DIFF
--- a/src/new_build.sh
+++ b/src/new_build.sh
@@ -374,7 +374,7 @@ for codename in ${devices//,/ }; do
       fi
 
       if [ "$android_version_major" -ge "10" ]; then
-        sed -i "1s;^;PRODUCT_DEFAULT_DEV_CERTIFICATE := user-keys/releasekey\nPRODUCT_OTA_PUBLIC_KEYS := user-keys/releasekey\n\n;" "vendor/$vendor/config/common.mk"
+        sed -i "1s;^;PRODUCT_DEFAULT_DEV_CERTIFICATE := user-keys/releasekey\nPRODUCT_OTA_PUBLIC_KEYS := user-keys/releasekey\nPRODUCT_MAINLINE_BLUETOOTH_SEPOLICY_DEV_CERTIFICATES := \$(dir \$(PRODUCT_DEFAULT_DEV_CERTIFICATE))\n\n;" "vendor/$vendor/config/common.mk"
       fi
     fi
 


### PR DESCRIPTION
Write the additional line to `vendor/lineage/config/common.mk`

Fixes #858