### PR TITLE
Fix `themuppets_branch` for iode7 builds of new devices

### DIFF
--- a/src/new_build.sh
+++ b/src/new_build.sh
@@ -155,7 +155,7 @@ case "$PRODUCT" in
         android_version=15
         ;;
       v7*)
-        themuppets_branch="lineage-23.0"
+        themuppets_branch="lineage-23.2"
         android_version=16
         ;;
       *)


### PR DESCRIPTION
`themuppets_branch` for iode 7 builds is 23.2 not 23.0 Fix #877