### PR TITLE
Use our own version of the PI patch

### DIFF
--- a/src/new_build.sh
+++ b/src/new_build.sh
@@ -429,8 +429,9 @@ for codename in ${devices//,/ }; do
 
       git reset --hard
       git clean -q -fd
-      wget -q https://git.disroot.org/flame-0/android_vendor_extra/raw/branch/main/patches/system_core/0001-Pass-SafetyNet.patch
-      git apply 0001-Pass-SafetyNet.patch &>> "$DEBUG_LOG" || {
+      #wget -q https://git.disroot.org/flame-0/android_vendor_extra/raw/branch/main/patches/system_core/0001-Pass-SafetyNet.patch
+      wget -q https://raw.githubusercontent.com/petefoth/android_vendor_extra/refs/heads/lineage-23.2/patches/system_core/0001-Pass-SafetyNet.patch && 
+        git apply 0001-Pass-SafetyNet.patch &>> "$DEBUG_LOG" || {
         echo ">> [$(date)] Error: Applying the PlayIntegrity patch failed for $codename on $branch!"; userscriptfail=true; continue; }
       cd ../..
     else

--- a/src/new_build.sh
+++ b/src/new_build.sh
@@ -429,7 +429,8 @@ for codename in ${devices//,/ }; do
 
       git reset --hard
       git clean -q -fd
-      wget -q https://raw.githubusercontent.com/petefoth/android_vendor_extra/refs/heads/lineage-23.2/patches/system_core/0001-Pass-SafetyNet.patch &>> "$DEBUG_LOG" || {
+     
+      wget -q https://raw.githubusercontent.com/lineageos4microg/patches/refs/heads/main/system_core/0001-Pass-SafetyNet.patch &>> "$DEBUG_LOG" || {
         echo ">> [$(date)] Error: Fetching the PlayIntegrity patch $codename on $branch!"; userscriptfail=true; continue; }
       git apply 0001-Pass-SafetyNet.patch &>> "$DEBUG_LOG" || {
         echo ">> [$(date)] Error: Applying the PlayIntegrity patch failed for $codename on $branch!"; userscriptfail=true; continue; }

--- a/src/new_build.sh
+++ b/src/new_build.sh
@@ -429,9 +429,9 @@ for codename in ${devices//,/ }; do
 
       git reset --hard
       git clean -q -fd
-      #wget -q https://git.disroot.org/flame-0/android_vendor_extra/raw/branch/main/patches/system_core/0001-Pass-SafetyNet.patch
-      wget -q https://raw.githubusercontent.com/petefoth/android_vendor_extra/refs/heads/lineage-23.2/patches/system_core/0001-Pass-SafetyNet.patch && 
-        git apply 0001-Pass-SafetyNet.patch &>> "$DEBUG_LOG" || {
+      wget -q https://raw.githubusercontent.com/petefoth/android_vendor_extra/refs/heads/lineage-23.2/patches/system_core/0001-Pass-SafetyNet.patch &>> "$DEBUG_LOG" || {
+        echo ">> [$(date)] Error: Fetching the PlayIntegrity patch $codename on $branch!"; userscriptfail=true; continue; }
+      git apply 0001-Pass-SafetyNet.patch &>> "$DEBUG_LOG" || {
         echo ">> [$(date)] Error: Applying the PlayIntegrity patch failed for $codename on $branch!"; userscriptfail=true; continue; }
       cd ../..
     else


### PR DESCRIPTION
I have created a fork of the `https://git.disroot.org/flame-0/android_vendor_extra` repo, which has the patch we need in the `lineage-23.2` branch.

https://github.com/petefoth/android_vendor_extra

Fixes #888